### PR TITLE
fix: add missing name field and allowed-tools to all 20 slash commands

### DIFF
--- a/commands/api-docs.md
+++ b/commands/api-docs.md
@@ -1,6 +1,8 @@
 ---
+name: api-docs
 agent: api-documenter
 description: Launch the API documentation specialist for OpenAPI specs
+allowed-tools: Task
 ---
 
 Create comprehensive API documentation with OpenAPI specifications and developer guides.

--- a/commands/api.md
+++ b/commands/api.md
@@ -1,6 +1,8 @@
 ---
+name: api
 agent: api-developer
 description: Launch the API development agent for backend implementation
+allowed-tools: Task
 ---
 
 Design and implement robust REST and GraphQL APIs with authentication and best practices.

--- a/commands/content.md
+++ b/commands/content.md
@@ -1,6 +1,8 @@
 ---
+name: content
 agent: marketing-writer
 description: Alternative command for content creation
+allowed-tools: Task
 ---
 
 Write SEO-optimized content and product messaging.

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -1,4 +1,5 @@
 ---
+name: debug
 description: Debug an error or issue
 allowed-tools: Task
 argument-hint: [error message or description]

--- a/commands/deploy.md
+++ b/commands/deploy.md
@@ -1,6 +1,8 @@
 ---
+name: deploy
 agent: devops-engineer
 description: Alternative command for DevOps deployment tasks
+allowed-tools: Task
 ---
 
 Deploy applications with automated pipelines and infrastructure management.

--- a/commands/devops.md
+++ b/commands/devops.md
@@ -1,6 +1,8 @@
 ---
+name: devops
 agent: devops-engineer
 description: Launch the DevOps specialist for CI/CD and deployment
+allowed-tools: Task
 ---
 
 Setup CI/CD pipelines, deployment automation, and infrastructure as code.

--- a/commands/document.md
+++ b/commands/document.md
@@ -1,4 +1,5 @@
 ---
+name: document
 description: Generate or update documentation
 allowed-tools: Task
 argument-hint: [what to document - e.g., API, README, specific module]

--- a/commands/frontend.md
+++ b/commands/frontend.md
@@ -1,6 +1,8 @@
 ---
+name: frontend
 agent: frontend-developer
 description: Launch the frontend development agent for UI implementation
+allowed-tools: Task
 ---
 
 Create modern, responsive web applications with React, Vue, or other frameworks.

--- a/commands/marketing.md
+++ b/commands/marketing.md
@@ -1,6 +1,8 @@
 ---
+name: marketing
 agent: marketing-writer
 description: Launch the marketing content specialist
+allowed-tools: Task
 ---
 
 Create compelling marketing content, landing pages, and technical blog posts.

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1,6 +1,8 @@
 ---
+name: plan
 agent: project-planner
 description: Launch the project planning agent for strategic task decomposition
+allowed-tools: Task
 ---
 
 Analyze complex projects and create actionable development plans with clear timelines and dependencies.

--- a/commands/product.md
+++ b/commands/product.md
@@ -1,6 +1,8 @@
 ---
+name: product
 agent: product-manager
 description: Launch the product management specialist
+allowed-tools: Task
 ---
 
 Create user stories, manage requirements, and plan product roadmaps.

--- a/commands/refactor.md
+++ b/commands/refactor.md
@@ -1,4 +1,5 @@
 ---
+name: refactor
 description: Refactor code for better structure and maintainability
 allowed-tools: Task
 argument-hint: [file/directory/pattern to refactor]

--- a/commands/requirements.md
+++ b/commands/requirements.md
@@ -1,6 +1,8 @@
 ---
+name: requirements
 agent: product-manager
 description: Alternative command for requirements gathering
+allowed-tools: Task
 ---
 
 Gather requirements and create detailed product specifications.

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,4 +1,5 @@
 ---
+name: review
 description: Trigger code review on recent changes
 allowed-tools: Task
 ---

--- a/commands/security-scan.md
+++ b/commands/security-scan.md
@@ -1,4 +1,5 @@
 ---
+name: security-scan
 description: Scan for security vulnerabilities
 allowed-tools: Task
 argument-hint: [specific directory or file pattern to scan]

--- a/commands/shadcn.md
+++ b/commands/shadcn.md
@@ -1,6 +1,8 @@
 ---
+name: shadcn
 agent: shadcn-ui-builder
 description: Launch the ShadCN UI builder agent for component-based UI development
+allowed-tools: Task
 ---
 
 Create accessible, responsive interfaces using ShadCN's comprehensive component system.

--- a/commands/tdd.md
+++ b/commands/tdd.md
@@ -1,6 +1,8 @@
 ---
+name: tdd
 agent: tdd-specialist
 description: Launch the TDD specialist for test-driven development
+allowed-tools: Task
 ---
 
 Implement comprehensive test suites following test-driven development principles.

--- a/commands/test-first.md
+++ b/commands/test-first.md
@@ -1,6 +1,8 @@
 ---
+name: test-first
 agent: tdd-specialist
 description: Alternative command for TDD specialist focusing on test-first approach
+allowed-tools: Task
 ---
 
 Write tests before implementation following the red-green-refactor cycle.

--- a/commands/test.md
+++ b/commands/test.md
@@ -1,4 +1,5 @@
 ---
+name: test
 description: Run tests and fix failures
 allowed-tools: Task
 argument-hint: [specific test file or pattern]

--- a/commands/ui.md
+++ b/commands/ui.md
@@ -1,6 +1,8 @@
 ---
+name: ui
 agent: shadcn-ui-builder
 description: Launch the ShadCN UI builder agent for interface design and implementation
+allowed-tools: Task
 ---
 
 Design and implement modern user interfaces using the ShadCN UI component library.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What this fixes

**Bug 1 — Missing `name` field (all 20 commands)**

Every slash command file in `commands/` was missing the required `name` frontmatter field. Without an explicit `name`, Claude Code falls back to filename-based registration only — which works for basic use but breaks discoverability in any registry or tooling that reads frontmatter directly. The `context-forge/` commands already include a `name` field; this PR brings the root-level commands into parity.

**Bug 2 — Missing `allowed-tools: Task` (14 agent-dispatch commands)**

Fourteen commands that dispatch to sub-agents were missing the `allowed-tools` declaration. Without it, Claude has no signal about which tools are permitted when executing the command. The three commands that already had `allowed-tools: Task` (`review`, `security-scan`, `test`) follow the correct pattern; this PR adds the same declaration to the 14 that were missing it.

## Changes

- Added `name: <command>` to all 20 command files
- Added `allowed-tools: Task` to the 14 agent-dispatch commands that were missing it (`api-docs`, `api`, `content`, `deploy`, `devops`, `frontend`, `marketing`, `plan`, `product`, `requirements`, `shadcn`, `tdd`, `test-first`, `ui`)
- No body text, agent wiring, or logic changed

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:341062493ffb42b377b32c8bcceb3e2e6ed2e97ff0fd450b6420a15eb3452837"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:6f6a38c86963d5c5bc001a83b5591a85c93ee59b78ff6bf399d118bedcf36fa0"}]}
nlpm-metadata-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only frontmatter additions to command markdown files; no execution logic or agent prompts changed beyond registration/permissions fields.
> 
> **Overview**
> Adds missing frontmatter `name` to all slash-command files under `commands/`, aligning registration with tools that read command metadata.
> 
> Also standardizes tool permissions by adding `allowed-tools: Task` to the agent-dispatch commands that were missing it (keeping existing command bodies/prompts unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297403a17908377f3b90c148f013d4e1badebbfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->