### PR TITLE
fix: add Bash tool and replace unresolvable MCP reference in shadcn-ui-builder

### DIFF
--- a/agents/shadcn-ui-builder/agent.md
+++ b/agents/shadcn-ui-builder/agent.md
@@ -1,7 +1,7 @@
 ---
 name: shadcn-ui-builder
 description: UI/UX specialist for designing and implementing interfaces using the ShadCN UI component library. Expert at creating modern, accessible, component-based designs.
-tools: Glob, Grep, LS, ExitPlanMode, Read, NotebookRead, WebFetch, TodoWrite, Task
+tools: Glob, Grep, LS, ExitPlanMode, Read, NotebookRead, WebFetch, TodoWrite, Task, Bash
 ---
 
 You are an expert Front-End Graphics and UI/UX Developer specializing in ShadCN UI implementation. Your deep expertise spans modern design principles, accessibility standards, component-based architecture, and the ShadCN design system.
@@ -17,7 +17,7 @@ You are an expert Front-End Graphics and UI/UX Developer specializing in ShadCN 
 
 ### Planning Phase
 When planning any ShadCN-related implementation:
-- ALWAYS use the MCP server during planning to access ShadCN resources
+- Use WebFetch to review the ShadCN component docs at https://ui.shadcn.com/docs/components before selecting components
 - Identify and apply appropriate ShadCN components for each UI element
 - Prioritize using complete blocks (e.g., full login pages, calendar widgets) unless the user specifically requests individual components
 - Create a comprehensive ui-implementation.md file outlining:


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What this fixes

### Bug 1 — `Bash` not declared, but installation commands required

`agents/shadcn-ui-builder/agent.md` instructs the agent to _"Install the required ShadCN components using the appropriate installation commands"_ (line 29), and again to _"Install components through official channels rather than writing files manually"_ (line 66). Running `npx shadcn@latest add <component>` requires a shell — but `Bash` is not present in the agent's `tools` frontmatter field. Without it, Claude Code will refuse to execute any shell command, and the installation step will silently fail.

**Fix**: Added `Bash` to the tools list.

### Bug 2 — MCP server reference with no `.mcp.json`

Line 20 instructs the agent to _"ALWAYS use the MCP server during planning to access ShadCN resources"_. However:
- No `.mcp.json` exists anywhere in the repository
- No MCP tool is declared in the agent's tools list

Every time the agent enters its planning phase, this instruction is unexecutable — the agent cannot access the described MCP resources and will silently skip or mishandle the planning step.

**Fix**: Replaced the unresolvable MCP instruction with a `WebFetch`-based alternative (fetching ShadCN's official component docs), which works with the already-declared `WebFetch` tool. If you do have a specific ShadCN MCP server in mind, adding a `.mcp.json` and restoring the MCP reference would be the preferred approach.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-undeclared-tool","fingerprint":"sha256:7541c23f3472a35b089014d1815a2d75588e31332b83b968287673256da300b6"},{"rule_id":"BUG-broken-reference","fingerprint":"sha256:ee487613d6a3603a4df81b546895c0c0b650d90f85bcefef77d8102cec327206"}]}
nlpm-metadata-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates agent configuration/instructions, with no runtime code or data-handling changes. Main impact is enabling shell execution via `Bash`, which could allow broader command execution if the agent is invoked in untrusted contexts.
> 
> **Overview**
> Updates the `shadcn-ui-builder` agent configuration to include the `Bash` tool so it can run ShadCN installation commands.
> 
> Replaces an unexecutable *“use the MCP server”* planning requirement with a `WebFetch` step that references the official ShadCN component docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24f7cbe3588df2b178ef05dfa3369aa28b5fd411. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->