### PR TITLE
fix: add missing name field to all 20 command frontmatter blocks

### DIFF
--- a/commands/api-docs.md
+++ b/commands/api-docs.md
@@ -1,4 +1,5 @@
 ---
+name: api-docs
 agent: api-documenter
 description: Launch the API documentation specialist for OpenAPI specs
 ---

--- a/commands/api.md
+++ b/commands/api.md
@@ -1,4 +1,5 @@
 ---
+name: api
 agent: api-developer
 description: Launch the API development agent for backend implementation
 ---

--- a/commands/content.md
+++ b/commands/content.md
@@ -1,4 +1,5 @@
 ---
+name: content
 agent: marketing-writer
 description: Alternative command for content creation
 ---

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -1,4 +1,5 @@
 ---
+name: debug
 description: Debug an error or issue
 allowed-tools: Task
 argument-hint: [error message or description]

--- a/commands/deploy.md
+++ b/commands/deploy.md
@@ -1,4 +1,5 @@
 ---
+name: deploy
 agent: devops-engineer
 description: Alternative command for DevOps deployment tasks
 ---

--- a/commands/devops.md
+++ b/commands/devops.md
@@ -1,4 +1,5 @@
 ---
+name: devops
 agent: devops-engineer
 description: Launch the DevOps specialist for CI/CD and deployment
 ---

--- a/commands/document.md
+++ b/commands/document.md
@@ -1,4 +1,5 @@
 ---
+name: document
 description: Generate or update documentation
 allowed-tools: Task
 argument-hint: [what to document - e.g., API, README, specific module]

--- a/commands/frontend.md
+++ b/commands/frontend.md
@@ -1,4 +1,5 @@
 ---
+name: frontend
 agent: frontend-developer
 description: Launch the frontend development agent for UI implementation
 ---

--- a/commands/marketing.md
+++ b/commands/marketing.md
@@ -1,4 +1,5 @@
 ---
+name: marketing
 agent: marketing-writer
 description: Launch the marketing content specialist
 ---

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1,4 +1,5 @@
 ---
+name: plan
 agent: project-planner
 description: Launch the project planning agent for strategic task decomposition
 ---

--- a/commands/product.md
+++ b/commands/product.md
@@ -1,4 +1,5 @@
 ---
+name: product
 agent: product-manager
 description: Launch the product management specialist
 ---

--- a/commands/refactor.md
+++ b/commands/refactor.md
@@ -1,4 +1,5 @@
 ---
+name: refactor
 description: Refactor code for better structure and maintainability
 allowed-tools: Task
 argument-hint: [file/directory/pattern to refactor]

--- a/commands/requirements.md
+++ b/commands/requirements.md
@@ -1,4 +1,5 @@
 ---
+name: requirements
 agent: product-manager
 description: Alternative command for requirements gathering
 ---

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,4 +1,5 @@
 ---
+name: review
 description: Trigger code review on recent changes
 allowed-tools: Task
 ---

--- a/commands/security-scan.md
+++ b/commands/security-scan.md
@@ -1,4 +1,5 @@
 ---
+name: security-scan
 description: Scan for security vulnerabilities
 allowed-tools: Task
 argument-hint: [specific directory or file pattern to scan]

--- a/commands/shadcn.md
+++ b/commands/shadcn.md
@@ -1,4 +1,5 @@
 ---
+name: shadcn
 agent: shadcn-ui-builder
 description: Launch the ShadCN UI builder agent for component-based UI development
 ---

--- a/commands/tdd.md
+++ b/commands/tdd.md
@@ -1,4 +1,5 @@
 ---
+name: tdd
 agent: tdd-specialist
 description: Launch the TDD specialist for test-driven development
 ---

--- a/commands/test-first.md
+++ b/commands/test-first.md
@@ -1,4 +1,5 @@
 ---
+name: test-first
 agent: tdd-specialist
 description: Alternative command for TDD specialist focusing on test-first approach
 ---

--- a/commands/test.md
+++ b/commands/test.md
@@ -1,4 +1,5 @@
 ---
+name: test
 description: Run tests and fix failures
 allowed-tools: Task
 argument-hint: [specific test file or pattern]

--- a/commands/ui.md
+++ b/commands/ui.md
@@ -1,4 +1,5 @@
 ---
+name: ui
 agent: shadcn-ui-builder
 description: Launch the ShadCN UI builder agent for interface design and implementation
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What and why

All 20 command files in `commands/` are missing the `name` field in their YAML frontmatter. Claude Code uses the `name` field for explicit command registration. Without it, the runtime falls back to the filename convention — which works in most cases, but any frontmatter-aware tool or registry that reads metadata directly (e.g., plugin marketplaces, command pickers, CI validators) will fail to find these commands by name.

Several sibling files in the repo already have `name` set correctly (e.g., the context-forge sub-commands). This PR brings all top-level commands into the same pattern.

## Fix

Added a `name: <filename-stem>` line to the frontmatter of each of the 20 affected files. No body text was changed.

Files modified:
`api-docs.md`, `api.md`, `content.md`, `debug.md`, `deploy.md`, `devops.md`, `document.md`, `frontend.md`, `marketing.md`, `plan.md`, `product.md`, `refactor.md`, `requirements.md`, `review.md`, `security-scan.md`, `shadcn.md`, `tdd.md`, `test-first.md`, `test.md`, `ui.md`

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:341062493ffb42b377b32c8bcceb3e2e6ed2e97ff0fd450b6420a15eb3452837"}]}
nlpm-metadata-end -->