### PR TITLE
fix: add allowed-tools: Task to 14 agent-dispatch commands

### DIFF
--- a/commands/api-docs.md
+++ b/commands/api-docs.md
@@ -1,6 +1,7 @@
 ---
 agent: api-documenter
 description: Launch the API documentation specialist for OpenAPI specs
+allowed-tools: Task
 ---
 
 Create comprehensive API documentation with OpenAPI specifications and developer guides.

--- a/commands/api.md
+++ b/commands/api.md
@@ -1,6 +1,7 @@
 ---
 agent: api-developer
 description: Launch the API development agent for backend implementation
+allowed-tools: Task
 ---
 
 Design and implement robust REST and GraphQL APIs with authentication and best practices.

--- a/commands/content.md
+++ b/commands/content.md
@@ -1,6 +1,7 @@
 ---
 agent: marketing-writer
 description: Alternative command for content creation
+allowed-tools: Task
 ---
 
 Write SEO-optimized content and product messaging.

--- a/commands/deploy.md
+++ b/commands/deploy.md
@@ -1,6 +1,7 @@
 ---
 agent: devops-engineer
 description: Alternative command for DevOps deployment tasks
+allowed-tools: Task
 ---
 
 Deploy applications with automated pipelines and infrastructure management.

--- a/commands/devops.md
+++ b/commands/devops.md
@@ -1,6 +1,7 @@
 ---
 agent: devops-engineer
 description: Launch the DevOps specialist for CI/CD and deployment
+allowed-tools: Task
 ---
 
 Setup CI/CD pipelines, deployment automation, and infrastructure as code.

--- a/commands/frontend.md
+++ b/commands/frontend.md
@@ -1,6 +1,7 @@
 ---
 agent: frontend-developer
 description: Launch the frontend development agent for UI implementation
+allowed-tools: Task
 ---
 
 Create modern, responsive web applications with React, Vue, or other frameworks.

--- a/commands/marketing.md
+++ b/commands/marketing.md
@@ -1,6 +1,7 @@
 ---
 agent: marketing-writer
 description: Launch the marketing content specialist
+allowed-tools: Task
 ---
 
 Create compelling marketing content, landing pages, and technical blog posts.

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1,6 +1,7 @@
 ---
 agent: project-planner
 description: Launch the project planning agent for strategic task decomposition
+allowed-tools: Task
 ---
 
 Analyze complex projects and create actionable development plans with clear timelines and dependencies.

--- a/commands/product.md
+++ b/commands/product.md
@@ -1,6 +1,7 @@
 ---
 agent: product-manager
 description: Launch the product management specialist
+allowed-tools: Task
 ---
 
 Create user stories, manage requirements, and plan product roadmaps.

--- a/commands/requirements.md
+++ b/commands/requirements.md
@@ -1,6 +1,7 @@
 ---
 agent: product-manager
 description: Alternative command for requirements gathering
+allowed-tools: Task
 ---
 
 Gather requirements and create detailed product specifications.

--- a/commands/shadcn.md
+++ b/commands/shadcn.md
@@ -1,6 +1,7 @@
 ---
 agent: shadcn-ui-builder
 description: Launch the ShadCN UI builder agent for component-based UI development
+allowed-tools: Task
 ---
 
 Create accessible, responsive interfaces using ShadCN's comprehensive component system.

--- a/commands/tdd.md
+++ b/commands/tdd.md
@@ -1,6 +1,7 @@
 ---
 agent: tdd-specialist
 description: Launch the TDD specialist for test-driven development
+allowed-tools: Task
 ---
 
 Implement comprehensive test suites following test-driven development principles.

--- a/commands/test-first.md
+++ b/commands/test-first.md
@@ -1,6 +1,7 @@
 ---
 agent: tdd-specialist
 description: Alternative command for TDD specialist focusing on test-first approach
+allowed-tools: Task
 ---
 
 Write tests before implementation following the red-green-refactor cycle.

--- a/commands/ui.md
+++ b/commands/ui.md
@@ -1,6 +1,7 @@
 ---
 agent: shadcn-ui-builder
 description: Launch the ShadCN UI builder agent for interface design and implementation
+allowed-tools: Task
 ---
 
 Design and implement modern user interfaces using the ShadCN UI component library.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What and why

14 of the command files in `commands/` dispatch to a sub-agent (they have an `agent:` key in frontmatter) but omit `allowed-tools`. The other 6 commands in the same directory — `debug.md`, `document.md`, `refactor.md`, `review.md`, `security-scan.md`, and `test.md` — already correctly declare `allowed-tools: Task`.

When `allowed-tools` is absent, Claude Code has no declared guidance on which tools the command may invoke. Adding `allowed-tools: Task` explicitly permits the `Task` tool (used to spawn sub-agents), matching the pattern already established by the non-agent commands in this repo.

## Fix

Added `allowed-tools: Task` to the frontmatter of all 14 affected agent-dispatch commands:
`api-docs.md`, `api.md`, `content.md`, `deploy.md`, `devops.md`, `frontend.md`, `marketing.md`, `plan.md`, `product.md`, `requirements.md`, `shadcn.md`, `tdd.md`, `test-first.md`, `ui.md`

No body text was changed.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:6f6a38c86963d5c5bc001a83b5591a85c93ee59b78ff6bf399d118bedcf36fa0"}]}
nlpm-metadata-end -->