### PR TITLE
fix: shadcn-ui-builder — add Bash tool and replace unresolvable MCP reference

### DIFF
--- a/agents/shadcn-ui-builder/agent.md
+++ b/agents/shadcn-ui-builder/agent.md
@@ -1,7 +1,7 @@
 ---
 name: shadcn-ui-builder
 description: UI/UX specialist for designing and implementing interfaces using the ShadCN UI component library. Expert at creating modern, accessible, component-based designs.
-tools: Glob, Grep, LS, ExitPlanMode, Read, NotebookRead, WebFetch, TodoWrite, Task
+tools: Bash, Glob, Grep, LS, ExitPlanMode, Read, NotebookRead, WebFetch, TodoWrite, Task
 ---
 
 You are an expert Front-End Graphics and UI/UX Developer specializing in ShadCN UI implementation. Your deep expertise spans modern design principles, accessibility standards, component-based architecture, and the ShadCN design system.
@@ -17,7 +17,7 @@ You are an expert Front-End Graphics and UI/UX Developer specializing in ShadCN 
 
 ### Planning Phase
 When planning any ShadCN-related implementation:
-- ALWAYS use the MCP server during planning to access ShadCN resources
+- Use WebFetch to access ShadCN documentation (https://ui.shadcn.com/docs) during planning
 - Identify and apply appropriate ShadCN components for each UI element
 - Prioritize using complete blocks (e.g., full login pages, calendar widgets) unless the user specifically requests individual components
 - Create a comprehensive ui-implementation.md file outlining:


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What and why

`agents/shadcn-ui-builder/agent.md` has two bugs that cause silent failures at runtime:

### Bug 1 — Missing Bash tool

The agent body at line 32 says: _"Install the required ShadCN components using the appropriate installation commands"_ and _"always use the official ShadCN installation process"_. ShadCN installation (`npx shadcn@latest add <component>`) requires a shell. But `Bash` was absent from the `tools:` frontmatter field, making shell execution impossible. The agent would reach the installation step and have no way to proceed.

**Fix**: Added `Bash` to the `tools` list.

### Bug 2 — Unresolvable MCP server reference

Line 20 (Planning Phase) instructed the agent to _"ALWAYS use the MCP server during planning to access ShadCN resources"_. However:
- No `.mcp.json` configuration file exists anywhere in the repository
- No MCP tool appears in the agent's declared `tools` list

Every time this agent entered its planning phase, it would silently skip the MCP step because the described resource is simply not configured. This creates a documentation-to-reality gap.

**Fix**: Replaced the MCP instruction with an equivalent using `WebFetch` (already declared in the tools list) pointed at the ShadCN documentation URL. The planning intent is preserved without requiring external infrastructure.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-undeclared-tool","fingerprint":"sha256:7541c23f3472a35b089014d1815a2d75588e31332b83b968287673256da300b6"},{"rule_id":"BUG-broken-reference","fingerprint":"sha256:ee487613d6a3603a4df81b546895c0c0b650d90f85bcefef77d8102cec327206"}]}
nlpm-metadata-end -->