### PR TITLE
Release v1.5.5 — voice integration, hooks, agent chaining, meta-agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,10 @@ dist
 # Claude agents specific
 .claude-agents.json
 *.local.json
+
+# Local Claude Code config (dev-only; the shippable template lives in templates/.claude/)
+.claude/
+
+# Voice/TTS test artifacts and scratch
+*.mp3
+tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,43 @@ Message 4: Bash("npm install")
 // This is 4x slower!
 ```
 
+## 🤖 Automatic Agent Orchestration
+
+You are an intelligent orchestrator. **PROACTIVELY** use specialized agents for every task:
+
+### Task Analysis Rules
+When receiving ANY task, immediately:
+1. **Identify Components**: Break down the task into specialized areas
+2. **Spawn Agents Concurrently**: Use multiple agents in parallel
+3. **Don't Ask Permission**: Just use agents - that's what they're for!
+
+### Automatic Triggers
+- **Code Changes** → Always spawn: `code-reviewer` + `test-runner`
+- **New Features** → Always spawn: `project-planner` + `tdd-specialist` + relevant developer
+- **Bug/Error** → Always spawn: `debugger` + `test-runner`
+- **Documentation** → Always spawn: `doc-writer` + `api-documenter`
+- **Deployment** → Always spawn: `devops-engineer` + `security-scanner`
+
+### Multi-Agent Patterns
+For complex tasks, spawn agent teams:
+
+**Full Stack Feature:**
+```javascript
+Task("project-planner: Design user authentication system")
+Task("api-developer: Implement auth endpoints")
+Task("frontend-developer: Create login/register UI")
+Task("tdd-specialist: Write comprehensive tests")
+Task("security-scanner: Verify auth security")
+```
+
+**Code Quality Check:**
+```javascript
+Task("code-reviewer: Review recent changes")
+Task("security-scanner: Check for vulnerabilities")
+Task("test-runner: Run all tests")
+Task("refactor: Suggest improvements")
+```
+
 ## 📋 Agent System Overview
 
 This project uses specialized AI agents for comprehensive software development, from planning to deployment and marketing.
@@ -102,21 +139,6 @@ memory.set("api:user:endpoints", {
 const endpoints = memory.get("api:user:endpoints");
 ```
 
-## 🪝 Hooks System
-
-Automated workflows triggered by agent actions:
-
-```json
-{
-  "PostToolUse:Edit": {
-    "commands": ["npm run lint", "npm test"]
-  },
-  "TaskComplete": {
-    "notify": "Task completed: {{task_name}}"
-  }
-}
-```
-
 ## 📊 Performance Guidelines
 
 ### Batch Operations for Speed
@@ -134,8 +156,7 @@ Automated workflows triggered by agent actions:
 1. **Always Think Concurrent**: Before any operation, ask "What else can I do in parallel?"
 2. **Use Agent Specialization**: Each agent is an expert - use the right one
 3. **Share Knowledge**: Use memory system for agent coordination
-4. **Automate with Hooks**: Set up workflows that run automatically
-5. **Monitor Performance**: Dashboard shows real-time metrics
+4. **Monitor Performance**: Dashboard shows real-time metrics
 
 ## 🚀 Quick Start Examples
 
@@ -165,5 +186,37 @@ Access the dashboard at http://localhost:7842:
 - **Task Queue**: Real-time execution monitoring
 - **Memory Viewer**: Inspect shared agent knowledge
 - **Performance Metrics**: Track improvements from concurrent execution
+
+## 🪝 Claude Code Hooks Integration
+
+Sub-agents automatically integrate with Claude Code hooks for enhanced workflow automation:
+
+### Hook Features
+- **Stop Hook** (`.claude/hooks/stop.py`): LLM-generated completion messages with TTS
+- **SubagentStop Hook** (`.claude/hooks/subagent_stop.py`): Agent-specific completion notifications
+- **Voice Announcements**: Automatic audio feedback when agents complete tasks
+
+### TTS Provider Priority
+1. **ElevenLabs MCP** (via Claude Code MCP integration) - Highest quality
+2. **OpenAI TTS** (via API key) - Fast and reliable
+3. **Local TTS** (pyttsx3) - Offline fallback
+
+### Personalization
+Set `ENGINEER_NAME=YourName` environment variable for personalized completion messages:
+- "John, all set!" 
+- "Ready for you, Sarah!"
+- "Complete, Alex!"
+
+### Configuration
+- **Permissions**: Configured in `.claude/settings.json`
+- **Hook Scripts**: Located in `.claude/hooks/` directory
+- **Utilities**: LLM and TTS utilities in `.claude/hooks/utils/`
+
+### Setup
+Hooks are automatically created during `claude-agents init`. The system will:
+1. Create `.claude/hooks/` directory structure
+2. Install hook scripts with UV single-file format
+3. Configure settings.json with proper permissions
+4. Set up TTS utilities with fallback chain
 
 Remember: **Concurrent execution is not optional - it's the foundation of efficient agent orchestration!**

--- a/README.md
+++ b/README.md
@@ -33,7 +33,24 @@ Claude Sub-Agents Manager is a powerful CLI tool that enhances Claude Code with 
 - **🛠️ Developer First**: Built by developers, for developers
 - **🔗 Context-Forge Integration**: Seamlessly works with context-forge projects and PRPs
 
-### 🎉 New in v1.4.0 - Context-Forge Integration
+### 🎉 New in v1.5.1 - Enhanced Voice Integration & Hook Improvements
+
+- **🔊 Voice Announcements**: Real-time audio feedback when agents complete tasks
+- **🎙️ ElevenLabs Integration**: High-quality voice synthesis with Sarah voice
+- **🪝 Improved Hook System**: Better settings.json merging during updates
+- **🔧 Voice Setup Wizard**: Interactive configuration with `claude-agents voice --setup`
+- **📢 Auto-Announcements**: Hear when sub-agents complete tasks in Claude Code
+- **🎯 FFmpeg Detection**: Automatic detection and installation guidance
+
+### 📦 New in v1.5.0 - Voice Features, Chaining & Meta-Agent
+
+- **🔗 Agent Chaining**: Run multiple agents in powerful sequences with data handoffs
+- **🤖 Meta-Agent**: Automatically generate new specialized agents from descriptions
+- **🎙️ Multiple TTS Providers**: ElevenLabs (via MCP), OpenAI, and local system TTS
+- **⚙️ Voice Configuration**: Easy setup with `claude-agents voice` command
+- **🎯 Enhanced Orchestration**: Context-preserving handoffs between agents
+
+### 📦 New in v1.4.0 - Context-Forge Integration
 
 - **🛠️ Full Context-Forge Support**: Automatic detection and smart integration
 - **📦 Init Command**: `claude-agents init` for one-command project setup
@@ -47,12 +64,17 @@ Claude Sub-Agents Manager is a powerful CLI tool that enhances Claude Code with 
 
 ### NPM (Recommended)
 ```bash
+# Install latest version
+npm install -g @webdevtoday/claude-agents@latest
+
+# Or install without @latest (gets latest by default)
 npm install -g @webdevtoday/claude-agents
 ```
 
 ### Yarn
 ```bash
-yarn global add @webdevtoday/claude-agents
+# Install latest version
+yarn global add @webdevtoday/claude-agents@latest
 ```
 
 ### From Source
@@ -61,6 +83,31 @@ git clone https://github.com/webdevtodayjason/sub-agents.git
 cd sub-agents
 npm install
 npm link
+```
+
+### 🔄 Updating Existing Installation
+
+If you already have claude-agents installed:
+
+```bash
+# Update to latest version
+npm update -g @webdevtoday/claude-agents@latest
+
+# Or with yarn
+yarn global upgrade @webdevtoday/claude-agents@latest
+```
+
+After updating the package, **update your projects** to get the latest features:
+
+```bash
+# In your project directory, run init to update hooks and configurations
+claude-agents init
+
+# This will:
+# - Update Claude Code hooks to latest versions
+# - Merge new hook configurations into existing settings.json
+# - Add any new agent features
+# - Preserve your existing configurations
 ```
 
 ## ⚡ Quick Start
@@ -84,6 +131,53 @@ claude-agents init --respect-context-forge
 # - Place commands in .claude/commands/agents/
 # - Append to CLAUDE.md without overwriting
 # - Work alongside your existing setup
+```
+
+## 🔊 Voice Setup (Optional)
+
+Voice announcements provide real-time audio feedback when agents complete tasks in Claude Code.
+
+### Quick Setup
+```bash
+# Run the interactive setup wizard
+claude-agents voice --setup
+
+# Or configure manually
+claude-agents voice --enable
+claude-agents voice --provider mcp  # or openai, local
+```
+
+### Voice Requirements
+
+#### Basic Voice (Local TTS)
+- **No additional requirements** - works out of the box
+- Uses system text-to-speech (macOS/Windows/Linux)
+
+#### High-Quality Voice (ElevenLabs/OpenAI)
+- **FFmpeg**: Required for audio playback
+  - macOS: `brew install ffmpeg`
+  - Windows: `choco install ffmpeg` or download from ffmpeg.org
+  - Linux: `sudo apt-get install ffmpeg`
+- **API Keys**: 
+  - ElevenLabs: Get from [elevenlabs.io](https://elevenlabs.io)
+  - OpenAI: Get from [platform.openai.com](https://platform.openai.com)
+
+### Voice Features
+- **Auto-Announcements**: Hear when sub-agents complete tasks
+- **AI Summaries**: OpenAI/Anthropic generates contextual completion messages
+- **Multiple Providers**: ElevenLabs (best quality), OpenAI, or local TTS
+- **Claude Code Integration**: Works seamlessly with hooks system
+
+### Testing Voice
+```bash
+# Test with default message
+claude-agents voice --test
+
+# Test with custom message
+claude-agents voice --test "Hello from Claude Agents"
+
+# Check voice status
+claude-agents voice --status
 ```
 
 ### Example Agent Tasks
@@ -121,6 +215,11 @@ claude-agents run devops-engineer --task "Create Docker configuration"
 # Product & Marketing
 claude-agents run product-manager --task "Create user stories from PRPs"
 claude-agents run marketing-writer --task "Write feature announcement for auth system"
+
+# Agent Chaining - NEW!
+claude-agents chain feature-development  # Full development pipeline
+claude-agents chain api-developer frontend-developer --task "Build user feature"
+claude-agents chain debugger api-developer test-runner --voice  # With voice announcements
 ```
 
 ### Using in Claude Code
@@ -155,6 +254,7 @@ claude-agents run marketing-writer --task "Write feature announcement for auth s
 | **devops-engineer** | DevOps specialist for CI/CD, infrastructure automation, and deployment | `/devops [task]` |
 | **product-manager** | Product management specialist for requirements, roadmaps, and user stories | `/product [feature]` |
 | **marketing-writer** | Marketing content specialist for technical marketing and product messaging | `/marketing [content]` |
+| **meta-agent** | Agent generator that creates new specialized agents from descriptions | `/meta [description]` |
 
 ## 🤖 Detailed Agent Descriptions
 
@@ -419,6 +519,128 @@ claude-agents install marketing-writer
 > /marketing product launch post
 > /marketing API feature announcement
 
+### 🤖 Meta-Agent
+*Agent generator for creating new specialized agents*
+
+- Fetches latest Claude Code documentation
+- Generates properly formatted agent files
+- Suggests optimal tool configurations
+- Creates both simple and complex agents
+- Follows best practices automatically
+
+```bash
+# Install
+claude-agents install meta-agent
+
+# Use
+> /meta create a database migration specialist
+> Task("meta-agent: create an agent for monitoring system performance")
+```
+
+## 🔊 Voice Features
+
+Enable real-time voice announcements for agent completions and errors:
+
+### Setup Voice
+
+#### Option 1: ElevenLabs via MCP (Recommended)
+
+Run this command to add the ElevenLabs MCP server:
+
+```bash
+claude mcp add ElevenLabs -e ELEVENLABS_API_KEY=your-api-key -- uvx elevenlabs-mcp
+```
+
+#### Option 2: OpenAI TTS
+
+```bash
+# Configure API key
+claude-agents voice --api-key
+
+# Select OpenAI and enter your API key
+```
+
+#### Option 3: Local System TTS
+
+Works out of the box on macOS (say), Linux (espeak), and Windows (PowerShell).
+
+### Using Voice
+
+```bash
+# Configure voice settings
+claude-agents voice
+
+# Enable/disable voice
+claude-agents voice --enable
+claude-agents voice --disable
+
+# Test voice
+claude-agents voice --test "Hello from Claude agents"
+
+# Run agent with voice
+claude-agents run api-developer --task "Create user API" --voice
+
+# Set voice provider
+claude-agents voice --provider mcp     # ElevenLabs via MCP
+claude-agents voice --provider openai  # OpenAI TTS
+claude-agents voice --provider local   # System TTS
+```
+
+### Voice Configuration
+
+Voice settings are stored in `~/.claude-agents/config.json`:
+
+```json
+{
+  "voice": {
+    "enabled": true,
+    "provider": "auto",
+    "announcements": {
+      "agentStart": false,
+      "agentComplete": true,
+      "errors": true,
+      "progress": false
+    }
+  }
+}
+```
+
+## 🚨 Troubleshooting
+
+### Hook Errors and API Failures
+
+If you're seeing errors like:
+- `Failed to spawn: .claude/hooks/stop.py`
+- `No such file or directory (os error 2)`
+- API Error 400: `tool_use ids were found without tool_result blocks`
+
+**Quick Fix:**
+```bash
+# In your project directory
+chmod +x .claude/hooks/*.py
+chmod +x .claude/hooks/utils/llm/*.py
+chmod +x .claude/hooks/utils/tts/*.py
+
+# Or run our fix script
+curl -sSL https://raw.githubusercontent.com/webdevtodayjason/sub-agents/main/scripts/fix-hooks.sh | bash
+```
+
+**Full Diagnosis:**
+```bash
+# Check your installation health
+claude-agents diagnose
+
+# Reinstall hooks with proper permissions
+claude-agents init
+```
+
+### Common Issues
+
+1. **Hooks not executable**: Run the chmod commands above
+2. **Hooks missing**: Run `claude-agents init` to restore
+3. **Python/uv not found**: Install uv from https://github.com/astral-sh/uv
+4. **Voice not working**: Install ffmpeg and run `claude-agents voice --setup`
+
 ## 📖 Documentation
 
 ### Command Reference
@@ -440,6 +662,9 @@ claude-agents install marketing-writer
 | `create` | Create a custom agent | `claude-agents create` |
 | `run <agent>` | Run agent independently | `claude-agents run marketing-writer --task "write launch post"` |
 | `dashboard` | Launch web dashboard | `claude-agents dashboard` |
+| `diagnose` | Check installation health | `claude-agents diagnose` |
+| `voice` | Configure voice settings | `claude-agents voice --setup` |
+| `chain` | Run multiple agents | `claude-agents chain api-developer test-runner` |
 
 ### Independent Agent Execution
 
@@ -680,7 +905,15 @@ DEBUG=claude-agents claude-agents run <agent> --task "test"
 
 ## 📊 Release Notes
 
-### Version 1.4.0 (Latest) - Context-Forge Integration
+### Version 1.5.0 (Latest) - Voice Features & Meta-Agent
+- 🔊 **Voice Announcements**: Real-time TTS feedback for agent completions
+- 🤖 **Meta-Agent**: Automatically generate new specialized agents
+- 🎙️ **MCP Integration**: ElevenLabs TTS via MCP server
+- 🔧 **Voice CLI**: Complete voice configuration command
+- 📝 **Enhanced CLAUDE.md**: More aggressive concurrent execution rules
+- ⚡ **Performance**: Improved agent orchestration patterns
+
+### Version 1.4.0 - Context-Forge Integration
 - 🛠️ **Context-Forge Support**: Full integration with context-forge projects
 - 📦 **Init Command**: One-command setup with `claude-agents init`
 - 🧹 **Uninstall Command**: Bulk removal with cleanup options

--- a/RELEASE_NOTES_1.5.1.md
+++ b/RELEASE_NOTES_1.5.1.md
@@ -1,0 +1,61 @@
+# Release Notes - v1.5.1
+
+## 🎉 Enhanced Voice Integration & Hook Improvements
+
+### 🔊 Voice Enhancements
+- **ElevenLabs Integration**: High-quality voice synthesis with Sarah voice for natural-sounding announcements
+- **Voice Setup Wizard**: New `claude-agents voice --setup` command provides interactive configuration
+- **FFmpeg Detection**: Automatic detection of FFmpeg with platform-specific installation guidance
+- **Auto-Announcements**: Voice notifications automatically play when sub-agents complete tasks in Claude Code
+
+### 🪝 Hook System Improvements
+- **Settings.json Merging**: Fixed issue where `claude-agents init` didn't properly update existing settings.json files
+- **Hook Installation**: All Python hooks (stop.py, subagent_stop.py, etc.) now properly install during init
+- **Preserved Configurations**: Init command now merges new hooks without overwriting existing configurations
+
+### 🔧 Bug Fixes
+- Fixed missing stop.py hook error during Claude Code execution
+- Fixed settings.json not updating with new hooks when running init on existing projects
+- Added templates directory to npm package files for proper distribution
+
+### 📦 Package Updates
+- Added templates/**/* to package.json files list
+- Improved init command to handle hook merging for existing projects
+- Enhanced voice command with comprehensive setup wizard
+
+### 📚 Documentation
+- Added voice setup requirements and installation instructions
+- Added update instructions for existing installations
+- Documented how to update projects after package updates
+- Added examples of installing with @latest tag
+
+## Updating from v1.5.0
+
+1. Update the package:
+```bash
+npm update -g @webdevtoday/claude-agents@latest
+```
+
+2. Update your projects:
+```bash
+# In each project directory
+claude-agents init
+```
+
+This will update your Claude Code hooks and merge new configurations while preserving your existing settings.
+
+## Voice Setup
+
+To enable voice announcements:
+```bash
+# Run the setup wizard
+claude-agents voice --setup
+```
+
+Requirements for high-quality voice:
+- FFmpeg (for audio playback)
+- API keys for ElevenLabs or OpenAI (optional, for better quality)
+
+---
+
+For more information, see the [README](README.md) or run `claude-agents --help`.

--- a/RELEASE_NOTES_1.5.5.md
+++ b/RELEASE_NOTES_1.5.5.md
@@ -1,0 +1,46 @@
+# Release Notes — v1.5.5
+
+First published release since **v1.4.0**. This rolls up the voice-integration and
+hooks work (previously drafted as 1.5.1) plus packaging fixes required to ship it
+safely, and triages the open community PRs.
+
+## 🔊 Voice Announcements
+- **Multi-provider TTS** with automatic fallback: ElevenLabs MCP → OpenAI → local (`pyttsx3`).
+- **`claude-agents voice`** — configure, enable/disable, set provider, check `--status`, and `--test` playback.
+- **`claude-agents setup`** — interactive wizard for agents, voice, and API keys (`--voice-only` available).
+- Per-agent completion announcements wired through Claude Code hooks.
+- New `work-completion-summary` agent for concise spoken task summaries.
+
+## 🪝 Hooks System
+- Python hook templates installed during `init` (`stop.py`, `subagent_stop.py`, `post_tool_use*.py`, `notification.py`).
+- `settings.json` is now **merged** on `init` rather than overwritten — existing config is preserved.
+- **`claude-agents diagnose`** — checks installation and hook health.
+
+## 🔗 Orchestration
+- **`claude-agents chain <agents...>`** — run agents in sequence or parallel, with `--save` to persist reusable chains and `--voice` announcements.
+- New **`meta-agent`** for generating agents.
+
+## 🛠️ Fixes
+- **Removed hardcoded absolute path.** Agent voice examples and the voice hook no longer hardcode a developer-specific `output_directory`; they now use the current project directory (`"."` / `process.cwd()`), so installs write audio to the user's own project.
+- **Context-forge command naming.** When installing into a context-forge project, command files are renamed to `agent-<command>.md` to avoid conflicts. Installs now rewrite the frontmatter `name` to match, so an explicit `name:` field can no longer defeat the conflict-avoidance prefix.
+- **`allowed-tools: Task`** added to the 14 agent-dispatch slash commands that were missing it (community PR #10).
+- `templates/**` is now included in the published package (`files`).
+- Repo hygiene: TTS scratch artifacts (`*.mp3`, `tmp/`) and dev-local `.claude/` are now gitignored.
+
+## 📦 Updating
+```bash
+npm install -g @webdevtoday/claude-agents@latest
+# then, in each project:
+claude-agents init
+```
+
+## Voice setup
+```bash
+claude-agents voice --setup
+```
+Optional for higher-quality voice: FFmpeg (playback) and an ElevenLabs or OpenAI API key.
+
+## 🙏 Community
+Thanks to **@xiaolai** for the automated NLPM audit PRs (#4–#11). #10 merged here;
+the command `name:` additions (#9) land on top of the context-forge fix above, and
+the shadcn-ui-builder tool fix (#5) is folded in.

--- a/VOICE_SETUP_GUIDE.md
+++ b/VOICE_SETUP_GUIDE.md
@@ -1,0 +1,200 @@
+# Voice Setup Guide for Claude Sub-Agents
+
+## Overview
+
+The enhanced voice command now provides a complete setup wizard that guides you through configuring voice functionality, checking dependencies, setting up API keys, and testing your configuration.
+
+## Quick Start
+
+```bash
+# Run the complete setup wizard
+claude-agents voice --setup
+
+# Check current status
+claude-agents voice --status
+
+# Test current configuration
+claude-agents voice --test
+```
+
+## Setup Wizard Features
+
+### 1. FFmpeg Detection
+The setup wizard automatically checks if FFmpeg is installed and provides platform-specific installation instructions:
+
+- **macOS**: `brew install ffmpeg`
+- **Windows**: `choco install ffmpeg` or download from ffmpeg.org
+- **Linux**: `sudo apt-get install ffmpeg` (Ubuntu/Debian)
+
+### 2. Voice Provider Selection
+Choose from multiple voice providers:
+
+- **Auto** (recommended): Uses the best available provider
+- **ElevenLabs MCP**: High-quality voice via Claude Code MCP integration
+- **OpenAI**: Reliable voice synthesis
+- **Local**: System text-to-speech (no API key required)
+
+### 3. API Key Configuration
+The wizard prompts for the necessary API keys based on your provider selection:
+
+- OpenAI API key for OpenAI provider
+- ElevenLabs API key for MCP/ElevenLabs provider
+- Multiple keys for Auto provider (optional but recommended)
+
+### 4. MCP Integration Setup
+For ElevenLabs MCP provider, the wizard:
+
+- Provides the exact command to run: `claude mcp add ElevenLabs -e ELEVENLABS_API_KEY=your-key -- uvx elevenlabs-mcp`
+- Optionally runs the command automatically
+- Configures Claude Code MCP integration
+
+### 5. Configuration Persistence
+Settings are saved to:
+- Configuration files for agent preferences
+- `.env` file for API keys and environment variables
+- Both local and global scopes as appropriate
+
+### 6. Voice Testing
+The wizard offers to test your configuration immediately after setup.
+
+## Command Options
+
+### Interactive Setup
+```bash
+claude-agents voice --setup
+```
+Runs the complete guided setup wizard.
+
+### Status Check
+```bash
+claude-agents voice --status
+```
+Shows comprehensive system status including:
+- FFmpeg installation status
+- Current configuration settings
+- API key configuration status
+- MCP integration status
+- Setup recommendations
+
+### Voice Testing
+```bash
+claude-agents voice --test
+claude-agents voice --test "Custom test message"
+```
+
+### Provider Configuration
+```bash
+claude-agents voice --provider auto
+claude-agents voice --provider mcp
+claude-agents voice --provider openai
+claude-agents voice --provider local
+```
+
+### Enable/Disable
+```bash
+claude-agents voice --enable
+claude-agents voice --disable
+```
+
+### API Key Setup
+```bash
+claude-agents voice --api-key
+```
+
+## Interactive Menu
+
+When you run `claude-agents voice` without options, you get an interactive menu with:
+
+1. **Enable/Disable voice**
+2. **Run setup wizard** - Complete guided setup
+3. **Show system status** - Detailed status information
+4. **Change provider** - Switch voice providers
+5. **Configure API keys** - Interactive API key setup
+6. **Test voice** - Test current configuration
+7. **View announcements settings** - Configure when voice announcements trigger
+
+## ElevenLabs MCP Integration
+
+For the highest quality voice experience, the wizard can set up ElevenLabs MCP integration:
+
+1. The wizard detects if you want to use ElevenLabs
+2. Prompts for your ElevenLabs API key
+3. Provides the exact MCP installation command
+4. Optionally runs the command automatically
+5. Configures Claude Code to use the ElevenLabs MCP server
+
+### Manual MCP Setup
+If you prefer to set up MCP manually:
+
+```bash
+claude mcp add ElevenLabs -e ELEVENLABS_API_KEY=your-api-key -- uvx elevenlabs-mcp
+```
+
+This command:
+- Installs the ElevenLabs MCP server
+- Configures it with your API key
+- Makes it available in Claude Code
+- Enables high-quality voice synthesis
+
+## Configuration Files
+
+### Environment Variables (.env)
+```env
+# Voice Configuration
+CLAUDE_AGENTS_VOICE_ENABLED=true
+CLAUDE_AGENTS_VOICE_PROVIDER=mcp
+ELEVENLABS_API_KEY=your-elevenlabs-key
+OPENAI_API_KEY=your-openai-key
+ANTHROPIC_API_KEY=your-anthropic-key
+```
+
+### Agent Configuration
+Voice settings are also stored in the agent configuration for persistence across sessions.
+
+## Troubleshooting
+
+### FFmpeg Issues
+If FFmpeg is not detected:
+1. Install using your platform's package manager
+2. Ensure it's in your system PATH
+3. Restart your terminal/shell
+4. Run the setup wizard again
+
+### API Key Issues
+If API keys aren't working:
+1. Verify the key is correct and active
+2. Check account billing/usage limits
+3. Ensure the key has the necessary permissions
+4. Try regenerating the API key
+
+### MCP Issues
+If ElevenLabs MCP isn't working:
+1. Ensure Claude Code is updated
+2. Check that the MCP server is properly installed
+3. Verify the API key is correctly configured
+4. Restart Claude Code
+
+## Best Practices
+
+1. **Start with the setup wizard**: Use `claude-agents voice --setup` for first-time configuration
+2. **Use status checks**: Regularly run `--status` to verify your configuration
+3. **Test frequently**: Use `--test` after making changes
+4. **Keep API keys secure**: Store them in `.env` files, not in code
+5. **Monitor usage**: Be aware of API costs and usage limits
+
+## Integration with Other Commands
+
+Voice features work seamlessly with other claude-agents commands:
+
+```bash
+# Enable voice for agent runs
+claude-agents run api-developer --task "Create user API" --voice
+
+# Chain commands with voice announcements
+claude-agents chain code-reviewer test-runner --voice
+
+# Voice announcements for specific events
+# (Configured through the announcements settings)
+```
+
+The setup wizard ensures your voice configuration works across all these use cases.

--- a/agents/api-developer/agent.md
+++ b/agents/api-developer/agent.md
@@ -300,3 +300,22 @@ const authenticate = async (req, res, next) => {
 ```
 
 Remember: Focus on creating clean, secure, well-documented APIs that follow industry best practices and are easy for other developers to understand and maintain.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've finished implementing the API endpoints. All tests are passing and documentation is updated.",
+  voice_id: "21m00Tcm4TlvDq8ikWAM",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Rachel (ID: 21m00Tcm4TlvDq8ikWAM) - Professional and authoritative
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/api-developer/metadata.json
+++ b/agents/api-developer/metadata.json
@@ -26,6 +26,8 @@
   },
   "commands": ["api"],
   "compatible_with": ["claude-code@>=1.0.0"],
+  "consumes": ["technical-plan", "api-specs", "test-specs", "bug-report"],
+  "produces": ["api-implementation", "endpoints", "api-code"],
   "examples": [
     {
       "trigger": "API creation request",

--- a/agents/api-documenter/agent.md
+++ b/agents/api-documenter/agent.md
@@ -298,3 +298,22 @@ curl https://api.example.com/v1/users \
 5. **Provide SDKs**: Generate client libraries when possible
 
 Remember: Great API documentation makes the difference between adoption and abandonment. Make it easy for developers to succeed with your API.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've documented the API. All endpoints are covered with examples.",
+  voice_id: "XB0fDUnXU5powFXDhCwa",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Charlotte - Charlotte - Swedish
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/api-documenter/metadata.json
+++ b/agents/api-documenter/metadata.json
@@ -3,10 +3,26 @@
   "version": "1.0.0",
   "description": "API documentation specialist for OpenAPI specs and developer guides",
   "author": "Claude Sub-Agents",
-  "tags": ["documentation", "api", "openapi", "swagger", "reference"],
+  "tags": [
+    "documentation",
+    "api",
+    "openapi",
+    "swagger",
+    "reference"
+  ],
   "requirements": {
-    "tools": ["Read", "Write", "Edit", "MultiEdit", "Grep", "Glob"],
-    "optional_tools": ["WebSearch", "WebFetch"]
+    "tools": [
+      "Read",
+      "Write",
+      "Edit",
+      "MultiEdit",
+      "Grep",
+      "Glob"
+    ],
+    "optional_tools": [
+      "WebSearch",
+      "WebFetch"
+    ]
   },
   "capabilities": [
     "openapi_generation",
@@ -17,20 +33,49 @@
     "versioning"
   ],
   "triggers": {
-    "keywords": ["api docs", "openapi", "swagger", "documentation", "reference"],
-    "patterns": ["document * api", "create api docs", "generate openapi"]
+    "keywords": [
+      "api docs",
+      "openapi",
+      "swagger",
+      "documentation",
+      "reference"
+    ],
+    "patterns": [
+      "document * api",
+      "create api docs",
+      "generate openapi"
+    ]
   },
   "hooks": {
-    "recommended": ["PostToolUse:Write", "PostToolUse:Edit"],
-    "optional": ["Stop"]
+    "recommended": [
+      "PostToolUse:Write",
+      "PostToolUse:Edit"
+    ],
+    "optional": [
+      "Stop"
+    ]
   },
-  "commands": ["api-docs"],
-  "compatible_with": ["claude-code@>=1.0.0"],
+  "commands": [
+    "api-docs"
+  ],
+  "compatible_with": [
+    "claude-code@>=1.0.0"
+  ],
   "examples": [
     {
       "trigger": "API documentation request",
       "request": "Generate OpenAPI documentation for our user API",
       "response": "I'll create comprehensive OpenAPI 3.0 documentation with examples"
     }
+  ],
+  "consumes": [
+    "api-implementation",
+    "endpoints",
+    "api-code"
+  ],
+  "produces": [
+    "api-documentation",
+    "openapi-spec",
+    "api-examples"
   ]
 }

--- a/agents/code-reviewer/agent.md
+++ b/agents/code-reviewer/agent.md
@@ -131,3 +131,22 @@ Improvements for code quality, readability, or following best practices.
 ```
 
 Remember: Your goal is to help create secure, maintainable, high-quality code. Be thorough but constructive.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've completed the code review. I've identified areas for improvement and security considerations.",
+  voice_id: "ErXwobaYiN019PkySvjV",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Antoni - Antoni - Precise
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/code-reviewer/metadata.json
+++ b/agents/code-reviewer/metadata.json
@@ -3,15 +3,47 @@
   "version": "1.0.0",
   "description": "Expert code review specialist for quality, security, and maintainability",
   "author": "Claude Sub-Agents",
-  "tags": ["code-quality", "review", "security", "best-practices"],
+  "tags": [
+    "code-quality",
+    "review",
+    "security",
+    "best-practices"
+  ],
   "requirements": {
-    "tools": ["Read", "Grep", "Glob", "Bash"],
-    "optional_tools": ["WebSearch"]
+    "tools": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Bash"
+    ],
+    "optional_tools": [
+      "WebSearch"
+    ]
   },
   "hooks": {
-    "recommended": ["PostToolUse:Edit", "PostToolUse:MultiEdit", "PostToolUse:Write"],
-    "optional": ["Stop"]
+    "recommended": [
+      "PostToolUse:Edit",
+      "PostToolUse:MultiEdit",
+      "PostToolUse:Write"
+    ],
+    "optional": [
+      "Stop"
+    ]
   },
-  "commands": ["review"],
-  "compatible_with": ["claude-code@>=1.0.0"]
+  "commands": [
+    "review"
+  ],
+  "compatible_with": [
+    "claude-code@>=1.0.0"
+  ],
+  "consumes": [
+    "code-changes",
+    "pull-request",
+    "implementation"
+  ],
+  "produces": [
+    "review-report",
+    "improvement-list",
+    "security-issues"
+  ]
 }

--- a/agents/debugger/agent.md
+++ b/agents/debugger/agent.md
@@ -247,3 +247,22 @@ After fixing, suggest improvements:
 5. Add logging for better debugging
 
 Remember: Every bug is an opportunity to improve the codebase. Fix the issue, then make it impossible to happen again.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've resolved the issue. The root cause has been fixed and verified.",
+  voice_id: "flq6f7yk4E4fJM5XTYuZ",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Michael - Michael - Serious
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/debugger/metadata.json
+++ b/agents/debugger/metadata.json
@@ -3,15 +3,47 @@
   "version": "1.0.0",
   "description": "Expert debugging specialist for analyzing errors, stack traces, and fixing issues",
   "author": "Claude Sub-Agents",
-  "tags": ["debugging", "error-analysis", "troubleshooting", "diagnostics"],
+  "tags": [
+    "debugging",
+    "error-analysis",
+    "troubleshooting",
+    "diagnostics"
+  ],
   "requirements": {
-    "tools": ["Read", "Edit", "Bash", "Grep", "Glob"],
-    "optional_tools": ["WebSearch", "MultiEdit"]
+    "tools": [
+      "Read",
+      "Edit",
+      "Bash",
+      "Grep",
+      "Glob"
+    ],
+    "optional_tools": [
+      "WebSearch",
+      "MultiEdit"
+    ]
   },
   "hooks": {
-    "recommended": ["PostToolUse:Bash"],
-    "optional": ["SubagentStop"]
+    "recommended": [
+      "PostToolUse:Bash"
+    ],
+    "optional": [
+      "SubagentStop"
+    ]
   },
-  "commands": ["debug"],
-  "compatible_with": ["claude-code@>=1.0.0"]
+  "commands": [
+    "debug"
+  ],
+  "compatible_with": [
+    "claude-code@>=1.0.0"
+  ],
+  "consumes": [
+    "error-report",
+    "failing-tests",
+    "bug-report"
+  ],
+  "produces": [
+    "root-cause",
+    "fix-strategy",
+    "debug-analysis"
+  ]
 }

--- a/agents/devops-engineer/agent.md
+++ b/agents/devops-engineer/agent.md
@@ -454,3 +454,22 @@ spec:
 ```
 
 Remember: Automate everything, monitor everything, and always have a rollback plan. The goal is to make deployments boring and predictable.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've set up the pipeline. Everything is configured and ready to use.",
+  voice_id: "2EiwWnXFnvU5JabPnv8n",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Clyde - Clyde - Technical
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/devops-engineer/metadata.json
+++ b/agents/devops-engineer/metadata.json
@@ -3,10 +3,28 @@
   "version": "1.0.0",
   "description": "DevOps specialist for CI/CD, infrastructure automation, and deployment",
   "author": "Claude Sub-Agents",
-  "tags": ["devops", "ci-cd", "deployment", "infrastructure", "automation", "kubernetes"],
+  "tags": [
+    "devops",
+    "ci-cd",
+    "deployment",
+    "infrastructure",
+    "automation",
+    "kubernetes"
+  ],
   "requirements": {
-    "tools": ["Read", "Write", "Edit", "MultiEdit", "Bash", "Grep", "Glob"],
-    "optional_tools": ["Task", "WebSearch"]
+    "tools": [
+      "Read",
+      "Write",
+      "Edit",
+      "MultiEdit",
+      "Bash",
+      "Grep",
+      "Glob"
+    ],
+    "optional_tools": [
+      "Task",
+      "WebSearch"
+    ]
   },
   "capabilities": [
     "ci_cd_pipelines",
@@ -17,15 +35,37 @@
     "security_automation"
   ],
   "triggers": {
-    "keywords": ["deploy", "ci/cd", "pipeline", "kubernetes", "docker", "infrastructure"],
-    "patterns": ["setup * deployment", "create * pipeline", "deploy to *"]
+    "keywords": [
+      "deploy",
+      "ci/cd",
+      "pipeline",
+      "kubernetes",
+      "docker",
+      "infrastructure"
+    ],
+    "patterns": [
+      "setup * deployment",
+      "create * pipeline",
+      "deploy to *"
+    ]
   },
   "hooks": {
-    "recommended": ["PostToolUse:Write", "PostToolUse:Bash"],
-    "optional": ["Stop", "PreToolUse:Bash"]
+    "recommended": [
+      "PostToolUse:Write",
+      "PostToolUse:Bash"
+    ],
+    "optional": [
+      "Stop",
+      "PreToolUse:Bash"
+    ]
   },
-  "commands": ["devops", "deploy"],
-  "compatible_with": ["claude-code@>=1.0.0"],
+  "commands": [
+    "devops",
+    "deploy"
+  ],
+  "compatible_with": [
+    "claude-code@>=1.0.0"
+  ],
   "examples": [
     {
       "trigger": "CI/CD setup",
@@ -37,5 +77,15 @@
       "request": "Deploy our API to Kubernetes",
       "response": "I'll create Kubernetes manifests and deployment configuration"
     }
+  ],
+  "consumes": [
+    "deployment-specs",
+    "infrastructure-requirements",
+    "security-report"
+  ],
+  "produces": [
+    "deployment-config",
+    "ci-cd-pipeline",
+    "infrastructure-code"
   ]
 }

--- a/agents/doc-writer/agent.md
+++ b/agents/doc-writer/agent.md
@@ -320,3 +320,22 @@ When analyzing code, automatically:
 6. Generate configuration docs
 
 Remember: Good documentation is an investment that pays dividends in reduced support time and increased adoption.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've written the documentation. All sections are complete and reviewed.",
+  voice_id: "z9fAnlkpzviPz146aGWa",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Glinda - Glinda - Witch
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/doc-writer/metadata.json
+++ b/agents/doc-writer/metadata.json
@@ -3,15 +3,46 @@
   "version": "1.0.0",
   "description": "Documentation specialist for creating and updating technical documentation, API docs, and README files",
   "author": "Claude Sub-Agents",
-  "tags": ["documentation", "technical-writing", "api-docs", "readme"],
+  "tags": [
+    "documentation",
+    "technical-writing",
+    "api-docs",
+    "readme"
+  ],
   "requirements": {
-    "tools": ["Read", "Write", "Edit", "Grep", "Glob"],
-    "optional_tools": ["Bash", "WebSearch"]
+    "tools": [
+      "Read",
+      "Write",
+      "Edit",
+      "Grep",
+      "Glob"
+    ],
+    "optional_tools": [
+      "Bash",
+      "WebSearch"
+    ]
   },
   "hooks": {
-    "recommended": ["PostToolUse:Write", "PostToolUse:Edit"],
+    "recommended": [
+      "PostToolUse:Write",
+      "PostToolUse:Edit"
+    ],
     "optional": []
   },
-  "commands": ["document"],
-  "compatible_with": ["claude-code@>=1.0.0"]
+  "commands": [
+    "document"
+  ],
+  "compatible_with": [
+    "claude-code@>=1.0.0"
+  ],
+  "consumes": [
+    "technical-specs",
+    "api-documentation",
+    "codebase"
+  ],
+  "produces": [
+    "user-guides",
+    "technical-docs",
+    "readme-files"
+  ]
 }

--- a/agents/frontend-developer/agent.md
+++ b/agents/frontend-developer/agent.md
@@ -271,3 +271,22 @@ export default defineConfig({
 ```
 
 Remember: Create intuitive, accessible, and performant user interfaces that delight users while maintaining clean, maintainable code.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've completed the UI implementation. The interface is responsive and ready for review.",
+  voice_id: "EXAVITQu4vr4xnSDxMaL",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Bella - Bella - Creative & Warm
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/frontend-developer/metadata.json
+++ b/agents/frontend-developer/metadata.json
@@ -26,6 +26,8 @@
   },
   "commands": ["frontend"],
   "compatible_with": ["claude-code@>=1.0.0"],
+  "consumes": ["api-endpoints", "ui-mockups", "user-stories", "components"],
+  "produces": ["ui-implementation", "ui-components", "frontend-code"],
   "examples": [
     {
       "trigger": "UI development request",

--- a/agents/marketing-writer/agent.md
+++ b/agents/marketing-writer/agent.md
@@ -370,3 +370,22 @@ memory.set("marketing:seo:keywords", {
 ```
 
 Remember: Great marketing makes the complex simple and the valuable obvious. Always lead with benefits, back with features, and prove with results.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've written the content. Everything is ready for publication.",
+  voice_id: "ThT5KcBeYPX3keUQqHPh",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Dorothy - Dorothy - Business
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/marketing-writer/metadata.json
+++ b/agents/marketing-writer/metadata.json
@@ -3,10 +3,27 @@
   "version": "1.0.0",
   "description": "Marketing content specialist for technical marketing and product messaging",
   "author": "Claude Sub-Agents",
-  "tags": ["marketing", "content", "copywriting", "seo", "landing-pages", "blog"],
+  "tags": [
+    "marketing",
+    "content",
+    "copywriting",
+    "seo",
+    "landing-pages",
+    "blog"
+  ],
   "requirements": {
-    "tools": ["Read", "Write", "Edit", "MultiEdit", "WebSearch", "Grep", "Glob"],
-    "optional_tools": ["WebFetch"]
+    "tools": [
+      "Read",
+      "Write",
+      "Edit",
+      "MultiEdit",
+      "WebSearch",
+      "Grep",
+      "Glob"
+    ],
+    "optional_tools": [
+      "WebFetch"
+    ]
   },
   "capabilities": [
     "landing_page_copy",
@@ -17,15 +34,36 @@
     "content_strategy"
   ],
   "triggers": {
-    "keywords": ["marketing", "content", "blog", "landing page", "copy", "announcement"],
-    "patterns": ["write * marketing", "create * content", "draft * announcement"]
+    "keywords": [
+      "marketing",
+      "content",
+      "blog",
+      "landing page",
+      "copy",
+      "announcement"
+    ],
+    "patterns": [
+      "write * marketing",
+      "create * content",
+      "draft * announcement"
+    ]
   },
   "hooks": {
-    "recommended": ["PostToolUse:Write", "PostToolUse:Edit"],
-    "optional": ["Stop"]
+    "recommended": [
+      "PostToolUse:Write",
+      "PostToolUse:Edit"
+    ],
+    "optional": [
+      "Stop"
+    ]
   },
-  "commands": ["marketing", "content"],
-  "compatible_with": ["claude-code@>=1.0.0"],
+  "commands": [
+    "marketing",
+    "content"
+  ],
+  "compatible_with": [
+    "claude-code@>=1.0.0"
+  ],
   "examples": [
     {
       "trigger": "Landing page creation",
@@ -37,5 +75,15 @@
       "request": "Write a blog post about DevOps best practices",
       "response": "I'll write an SEO-optimized technical blog post"
     }
+  ],
+  "consumes": [
+    "product-specs",
+    "user-guides",
+    "feature-list"
+  ],
+  "produces": [
+    "marketing-content",
+    "landing-page",
+    "blog-posts"
   ]
 }

--- a/agents/meta-agent/agent.md
+++ b/agents/meta-agent/agent.md
@@ -1,0 +1,167 @@
+---
+name: meta-agent
+description: Generates new, complete Claude Code sub-agent configuration files from descriptions. Use this to create new agents. Use PROACTIVELY when users ask to create new sub-agents.
+tools: Write, WebFetch, MultiEdit
+---
+
+# Purpose
+
+You are an expert agent architect specializing in creating high-quality Claude Code sub-agents. Your sole purpose is to take a user's description of a new sub-agent and generate a complete, ready-to-use sub-agent configuration file that follows best practices and maximizes effectiveness.
+
+## Core Competencies
+
+1. **Agent Design**: Creating focused, single-purpose agents with clear responsibilities
+2. **System Prompts**: Writing detailed, actionable prompts that guide agent behavior
+3. **Tool Selection**: Choosing the minimal set of tools needed for the agent's purpose
+4. **Best Practices**: Following Claude Code sub-agent conventions and patterns
+
+## Instructions
+
+When invoked, you must follow these steps:
+
+### 1. Gather Latest Documentation
+First, fetch the latest Claude Code sub-agents documentation to ensure you're using current best practices:
+- Fetch: `https://docs.anthropic.com/en/docs/claude-code/sub-agents`
+- Fetch: `https://docs.anthropic.com/en/docs/claude-code/settings#tools-available-to-claude`
+
+### 2. Analyze Requirements
+Carefully analyze the user's description to understand:
+- The agent's primary purpose and domain
+- Key tasks it will perform
+- Required capabilities and constraints
+- Expected outputs and reporting format
+
+### 3. Design Agent Structure
+Create a well-structured agent with:
+- **Descriptive name**: Use kebab-case (e.g., `data-analyzer`, `code-optimizer`)
+- **Clear description**: Write an action-oriented description that tells Claude when to use this agent
+- **Minimal tools**: Select only the tools necessary for the agent's tasks
+- **Focused prompt**: Create a system prompt that clearly defines the agent's role
+
+### 4. Select Appropriate Tools
+Based on the agent's tasks, choose from available tools:
+- **File operations**: Read, Write, Edit, MultiEdit
+- **Search operations**: Grep, Glob
+- **Execution**: Bash, Task
+- **Analysis**: WebFetch, WebSearch
+- **Specialized**: NotebookRead, NotebookEdit, etc.
+
+### 5. Write System Prompt
+Create a comprehensive system prompt that includes:
+- Clear role definition
+- Step-by-step instructions
+- Best practices for the domain
+- Output format requirements
+- Error handling guidelines
+
+### 6. Generate Agent File
+Write the complete agent configuration to the appropriate location:
+- Project agents: `.claude/agents/<agent-name>.md`
+- User agents: `~/.claude/agents/<agent-name>.md` (if specified)
+
+## Output Format
+
+Generate a complete Markdown file with this exact structure:
+
+```markdown
+---
+name: <agent-name>
+description: <action-oriented description of when to use this agent>
+tools: <tool1>, <tool2>, <tool3>  # Only if specific tools needed
+---
+
+# Purpose
+
+You are a <role definition>. <Detailed description of expertise and responsibilities>.
+
+## Core Competencies
+
+1. **<Competency 1>**: <Description>
+2. **<Competency 2>**: <Description>
+3. **<Competency 3>**: <Description>
+
+## Instructions
+
+When invoked, you must follow these steps:
+
+### Step 1: <Action>
+<Detailed instructions for this step>
+
+### Step 2: <Action>
+<Detailed instructions for this step>
+
+### Step 3: <Action>
+<Detailed instructions for this step>
+
+## Best Practices
+
+- <Best practice 1>
+- <Best practice 2>
+- <Best practice 3>
+
+## Output Format
+
+<Describe how the agent should format and present its results>
+
+## Error Handling
+
+<Guidelines for handling common errors or edge cases>
+```
+
+## Best Practices for Agent Creation
+
+1. **Single Responsibility**: Each agent should excel at one thing
+2. **Clear Triggers**: The description field should make it obvious when to use the agent
+3. **Minimal Tools**: Only grant tools that are essential for the agent's purpose
+4. **Detailed Instructions**: Provide step-by-step guidance in the system prompt
+5. **Actionable Output**: Define clear output formats that are useful to the user
+
+## Example Descriptions
+
+Good descriptions that encourage proactive use:
+- "Expert code review specialist. Use PROACTIVELY after any code changes."
+- "Database query optimizer. MUST BE USED for all SQL performance issues."
+- "Security vulnerability scanner. Use immediately when handling auth or sensitive data."
+
+## Common Agent Patterns
+
+### Analysis Agents
+- Tools: Read, Grep, Glob
+- Focus: Finding patterns, identifying issues
+- Output: Structured reports with findings
+
+### Implementation Agents
+- Tools: Write, Edit, MultiEdit, Bash
+- Focus: Creating or modifying code/content
+- Output: Completed implementations with explanations
+
+### Testing Agents
+- Tools: Read, Bash, Write
+- Focus: Running tests, validating behavior
+- Output: Test results with recommendations
+
+### Documentation Agents
+- Tools: Read, Write, Glob
+- Focus: Creating comprehensive documentation
+- Output: Well-formatted documentation files
+
+Remember: The goal is to create agents that are so well-designed that Claude will naturally want to use them for appropriate tasks. Make the agent's value proposition clear and its instructions foolproof.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've created the new agent. It's ready to use with the specialized capabilities.",
+  voice_id: "zrHiDhphv9ZnVXBqCLjz",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Mimi - Mimi - Playful
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/meta-agent/metadata.json
+++ b/agents/meta-agent/metadata.json
@@ -1,0 +1,41 @@
+{
+  "name": "meta-agent",
+  "version": "1.0.0",
+  "description": "Agent generator that creates new sub-agents from descriptions",
+  "author": "Claude Sub-Agents Manager",
+  "category": "meta",
+  "tags": [
+    "agent-creation",
+    "meta",
+    "generator",
+    "automation"
+  ],
+  "examples": [
+    {
+      "prompt": "Create a sub-agent that monitors system performance",
+      "description": "Generates a performance monitoring agent with appropriate tools"
+    },
+    {
+      "prompt": "Build an agent for managing git workflows",
+      "description": "Creates a git specialist agent with version control capabilities"
+    },
+    {
+      "prompt": "Make an agent that can analyze and optimize database queries",
+      "description": "Generates a database optimization specialist"
+    }
+  ],
+  "bestPractices": [
+    "Use the meta-agent when you need to create specialized agents quickly",
+    "Provide detailed descriptions of what the new agent should do",
+    "Review and customize the generated agent for your specific needs",
+    "The meta-agent follows current Claude Code documentation and best practices"
+  ],
+  "consumes": [
+    "agent-requirements",
+    "capability-gap"
+  ],
+  "produces": [
+    "new-agent",
+    "agent-config"
+  ]
+}

--- a/agents/product-manager/agent.md
+++ b/agents/product-manager/agent.md
@@ -340,3 +340,22 @@ We'd love to hear your thoughts! [Feedback link]
 ```
 
 Remember: Great products solve real problems for real people. Stay close to your users, validate assumptions quickly, and always be ready to pivot based on learning.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've completed the requirements. User stories and acceptance criteria are documented.",
+  voice_id: "nPczCjzI2devNBz1zQrb",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Brian - Brian - Trustworthy
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/product-manager/metadata.json
+++ b/agents/product-manager/metadata.json
@@ -3,10 +3,27 @@
   "version": "1.0.0",
   "description": "Product management specialist for requirements, user stories, and roadmaps",
   "author": "Claude Sub-Agents",
-  "tags": ["product", "requirements", "user-stories", "roadmap", "agile", "planning"],
+  "tags": [
+    "product",
+    "requirements",
+    "user-stories",
+    "roadmap",
+    "agile",
+    "planning"
+  ],
   "requirements": {
-    "tools": ["Read", "Write", "Edit", "Grep", "Glob", "TodoWrite"],
-    "optional_tools": ["Task", "WebSearch"]
+    "tools": [
+      "Read",
+      "Write",
+      "Edit",
+      "Grep",
+      "Glob",
+      "TodoWrite"
+    ],
+    "optional_tools": [
+      "Task",
+      "WebSearch"
+    ]
   },
   "capabilities": [
     "requirements_gathering",
@@ -17,15 +34,36 @@
     "agile_facilitation"
   ],
   "triggers": {
-    "keywords": ["requirements", "user story", "roadmap", "product", "feature", "backlog"],
-    "patterns": ["create * requirements", "write user stories", "plan * roadmap"]
+    "keywords": [
+      "requirements",
+      "user story",
+      "roadmap",
+      "product",
+      "feature",
+      "backlog"
+    ],
+    "patterns": [
+      "create * requirements",
+      "write user stories",
+      "plan * roadmap"
+    ]
   },
   "hooks": {
-    "recommended": ["PostToolUse:Write", "PostToolUse:TodoWrite"],
-    "optional": ["Stop"]
+    "recommended": [
+      "PostToolUse:Write",
+      "PostToolUse:TodoWrite"
+    ],
+    "optional": [
+      "Stop"
+    ]
   },
-  "commands": ["product", "requirements"],
-  "compatible_with": ["claude-code@>=1.0.0"],
+  "commands": [
+    "product",
+    "requirements"
+  ],
+  "compatible_with": [
+    "claude-code@>=1.0.0"
+  ],
   "examples": [
     {
       "trigger": "User story creation",
@@ -37,5 +75,16 @@
       "request": "Create a product roadmap for Q3",
       "response": "I'll develop a strategic roadmap with priorities and timelines"
     }
+  ],
+  "consumes": [
+    "project-brief",
+    "market-research",
+    "user-feedback"
+  ],
+  "produces": [
+    "user-stories",
+    "requirements",
+    "acceptance-criteria",
+    "product-specs"
   ]
 }

--- a/agents/project-planner/agent.md
+++ b/agents/project-planner/agent.md
@@ -289,3 +289,22 @@ if (memory.isContextForgeProject()) {
 ```
 
 Remember: Your role is to transform ideas into actionable, efficient development plans that leverage the full power of the agent ecosystem while maintaining clarity and achievability.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've completed the project planning. The roadmap is ready with clear milestones and deliverables.",
+  voice_id: "onwK4e9ZLuTAKqWW03F9",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Daniel - Daniel - Clear & Professional
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/project-planner/metadata.json
+++ b/agents/project-planner/metadata.json
@@ -26,6 +26,8 @@
   },
   "commands": ["plan"],
   "compatible_with": ["claude-code@>=1.0.0"],
+  "consumes": ["requirements", "user-stories", "project-brief"],
+  "produces": ["technical-plan", "task-breakdown", "milestones", "dependencies"],
   "examples": [
     {
       "trigger": "Complex project request",

--- a/agents/refactor/agent.md
+++ b/agents/refactor/agent.md
@@ -314,3 +314,22 @@ Before completing refactoring:
 - [ ] Documentation updated if needed
 
 Remember: The best refactoring is invisible to the end user but makes developers' lives easier.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've refactored the code. The structure is improved and all tests are passing.",
+  voice_id: "GBv7mTt0atIp3Br8iCZE",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Thomas - Thomas - Calm
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/refactor/metadata.json
+++ b/agents/refactor/metadata.json
@@ -3,15 +3,45 @@
   "version": "1.0.0",
   "description": "Code refactoring specialist for improving code structure, patterns, and maintainability",
   "author": "Claude Sub-Agents",
-  "tags": ["refactoring", "code-quality", "patterns", "clean-code"],
+  "tags": [
+    "refactoring",
+    "code-quality",
+    "patterns",
+    "clean-code"
+  ],
   "requirements": {
-    "tools": ["Read", "Edit", "MultiEdit", "Grep", "Glob"],
-    "optional_tools": ["Bash", "WebSearch"]
+    "tools": [
+      "Read",
+      "Edit",
+      "MultiEdit",
+      "Grep",
+      "Glob"
+    ],
+    "optional_tools": [
+      "Bash",
+      "WebSearch"
+    ]
   },
   "hooks": {
     "recommended": [],
-    "optional": ["PreToolUse:Edit"]
+    "optional": [
+      "PreToolUse:Edit"
+    ]
   },
-  "commands": ["refactor"],
-  "compatible_with": ["claude-code@>=1.0.0"]
+  "commands": [
+    "refactor"
+  ],
+  "compatible_with": [
+    "claude-code@>=1.0.0"
+  ],
+  "consumes": [
+    "code-issues",
+    "improvement-list",
+    "codebase"
+  ],
+  "produces": [
+    "refactored-code",
+    "improvement-report",
+    "code-changes"
+  ]
 }

--- a/agents/security-scanner/agent.md
+++ b/agents/security-scanner/agent.md
@@ -241,3 +241,22 @@ Consider requirements for:
 - SOC 2 (security controls)
 
 Remember: Security is not a one-time check but an ongoing process. Every vulnerability found and fixed makes the application more resilient.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've completed the security scan. All vulnerabilities have been documented.",
+  voice_id: "TX3LPaxmHKxFdv7VOQHJ",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Liam - Liam - Stoic
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/security-scanner/metadata.json
+++ b/agents/security-scanner/metadata.json
@@ -3,15 +3,47 @@
   "version": "1.0.0",
   "description": "Security vulnerability scanner that detects common security issues and suggests fixes",
   "author": "Claude Sub-Agents",
-  "tags": ["security", "vulnerability", "scanner", "audit"],
+  "tags": [
+    "security",
+    "vulnerability",
+    "scanner",
+    "audit"
+  ],
   "requirements": {
-    "tools": ["Read", "Grep", "Glob", "Bash"],
-    "optional_tools": ["WebSearch", "Edit"]
+    "tools": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Bash"
+    ],
+    "optional_tools": [
+      "WebSearch",
+      "Edit"
+    ]
   },
   "hooks": {
-    "recommended": ["PostToolUse:Write", "PreToolUse:Bash"],
-    "optional": ["Stop"]
+    "recommended": [
+      "PostToolUse:Write",
+      "PreToolUse:Bash"
+    ],
+    "optional": [
+      "Stop"
+    ]
   },
-  "commands": ["security-scan"],
-  "compatible_with": ["claude-code@>=1.0.0"]
+  "commands": [
+    "security-scan"
+  ],
+  "compatible_with": [
+    "claude-code@>=1.0.0"
+  ],
+  "consumes": [
+    "codebase",
+    "api-implementation",
+    "deployment-config"
+  ],
+  "produces": [
+    "vulnerability-report",
+    "security-issues",
+    "compliance-report"
+  ]
 }

--- a/agents/shadcn-ui-builder/agent.md
+++ b/agents/shadcn-ui-builder/agent.md
@@ -1,7 +1,7 @@
 ---
 name: shadcn-ui-builder
 description: UI/UX specialist for designing and implementing interfaces using the ShadCN UI component library. Expert at creating modern, accessible, component-based designs.
-tools: Glob, Grep, LS, ExitPlanMode, Read, NotebookRead, WebFetch, TodoWrite, Task
+tools: Glob, Grep, LS, ExitPlanMode, Read, NotebookRead, WebFetch, TodoWrite, Task, Bash
 ---
 
 You are an expert Front-End Graphics and UI/UX Developer specializing in ShadCN UI implementation. Your deep expertise spans modern design principles, accessibility standards, component-based architecture, and the ShadCN design system.
@@ -17,7 +17,7 @@ You are an expert Front-End Graphics and UI/UX Developer specializing in ShadCN 
 
 ### Planning Phase
 When planning any ShadCN-related implementation:
-- ALWAYS use the MCP server during planning to access ShadCN resources
+- Use WebFetch to review the ShadCN component docs at https://ui.shadcn.com/docs/components before selecting components
 - Identify and apply appropriate ShadCN components for each UI element
 - Prioritize using complete blocks (e.g., full login pages, calendar widgets) unless the user specifically requests individual components
 - Create a comprehensive ui-implementation.md file outlining:
@@ -119,3 +119,22 @@ When asked to create a login page:
 7. **Documentation**: Update relevant documentation with implementation details
 
 Remember: You are proactive in identifying opportunities to enhance UI/UX through ShadCN's component ecosystem, always considering user needs, accessibility, and modern design standards in your implementations.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've built the UI components. The interface is complete and follows design guidelines.",
+  voice_id: "jsCqWAovK2LkecY7zXl4",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Elli - Elli - Engaging
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/shadcn-ui-builder/metadata.json
+++ b/agents/shadcn-ui-builder/metadata.json
@@ -3,17 +3,50 @@
   "version": "1.0.0",
   "description": "UI/UX specialist for designing and implementing interfaces using ShadCN UI components",
   "author": "Claude Sub-Agents",
-  "tags": ["ui", "ux", "shadcn", "components", "frontend", "design", "accessibility"],
+  "tags": [
+    "ui",
+    "ux",
+    "shadcn",
+    "components",
+    "frontend",
+    "design",
+    "accessibility"
+  ],
   "requirements": {
-    "tools": ["Glob", "Grep", "LS", "Read", "WebFetch", "TodoWrite", "Task"],
-    "optional_tools": ["ExitPlanMode", "NotebookRead", "Edit", "Write", "MultiEdit"]
+    "tools": [
+      "Glob",
+      "Grep",
+      "LS",
+      "Read",
+      "WebFetch",
+      "TodoWrite",
+      "Task"
+    ],
+    "optional_tools": [
+      "ExitPlanMode",
+      "NotebookRead",
+      "Edit",
+      "Write",
+      "MultiEdit"
+    ]
   },
   "hooks": {
-    "recommended": ["PostToolUse:Write", "PostToolUse:Edit"],
-    "optional": ["Stop", "PostToolUse:MultiEdit"]
+    "recommended": [
+      "PostToolUse:Write",
+      "PostToolUse:Edit"
+    ],
+    "optional": [
+      "Stop",
+      "PostToolUse:MultiEdit"
+    ]
   },
-  "commands": ["ui", "shadcn"],
-  "compatible_with": ["claude-code@>=1.0.0"],
+  "commands": [
+    "ui",
+    "shadcn"
+  ],
+  "compatible_with": [
+    "claude-code@>=1.0.0"
+  ],
   "examples": [
     {
       "trigger": "User needs UI implementation",
@@ -30,5 +63,15 @@
       "request": "I'm working on a dashboard that needs charts, cards, and a navigation sidebar",
       "response": "I'll use the shadcn-ui-builder agent to design your dashboard using ShadCN's component system"
     }
+  ],
+  "consumes": [
+    "ui-requirements",
+    "design-system",
+    "component-list"
+  ],
+  "produces": [
+    "ui-components",
+    "component-library",
+    "shadcn-config"
   ]
 }

--- a/agents/tdd-specialist/agent.md
+++ b/agents/tdd-specialist/agent.md
@@ -318,3 +318,22 @@ describe('Performance', () => {
 ```
 
 Remember: Good tests are the foundation of maintainable code. Write tests that are clear, focused, and provide confidence in your implementation.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've written comprehensive tests. All tests are passing with good coverage.",
+  voice_id: "yoZ06aMxZJJ28mfd3POQ",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Sam - Sam - Problem Solver
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/tdd-specialist/metadata.json
+++ b/agents/tdd-specialist/metadata.json
@@ -3,10 +3,26 @@
   "version": "1.0.0",
   "description": "Test-Driven Development specialist for comprehensive testing strategies",
   "author": "Claude Sub-Agents",
-  "tags": ["testing", "tdd", "quality", "unit-tests", "integration-tests"],
+  "tags": [
+    "testing",
+    "tdd",
+    "quality",
+    "unit-tests",
+    "integration-tests"
+  ],
   "requirements": {
-    "tools": ["Read", "Write", "Edit", "MultiEdit", "Bash", "Grep", "Glob"],
-    "optional_tools": ["Task"]
+    "tools": [
+      "Read",
+      "Write",
+      "Edit",
+      "MultiEdit",
+      "Bash",
+      "Grep",
+      "Glob"
+    ],
+    "optional_tools": [
+      "Task"
+    ]
   },
   "capabilities": [
     "test_first_development",
@@ -17,15 +33,37 @@
     "test_refactoring"
   ],
   "triggers": {
-    "keywords": ["test", "tdd", "coverage", "unit", "integration", "mock"],
-    "patterns": ["write * tests", "test * feature", "add test coverage"]
+    "keywords": [
+      "test",
+      "tdd",
+      "coverage",
+      "unit",
+      "integration",
+      "mock"
+    ],
+    "patterns": [
+      "write * tests",
+      "test * feature",
+      "add test coverage"
+    ]
   },
   "hooks": {
-    "recommended": ["PostToolUse:Write", "PostToolUse:Edit", "PostToolUse:Bash"],
-    "optional": ["Stop"]
+    "recommended": [
+      "PostToolUse:Write",
+      "PostToolUse:Edit",
+      "PostToolUse:Bash"
+    ],
+    "optional": [
+      "Stop"
+    ]
   },
-  "commands": ["tdd", "test-first"],
-  "compatible_with": ["claude-code@>=1.0.0"],
+  "commands": [
+    "tdd",
+    "test-first"
+  ],
+  "compatible_with": [
+    "claude-code@>=1.0.0"
+  ],
   "examples": [
     {
       "trigger": "TDD request",
@@ -37,5 +75,16 @@
       "request": "Add tests for the payment service",
       "response": "I'll create unit and integration tests for complete coverage"
     }
+  ],
+  "consumes": [
+    "technical-plan",
+    "api-specs",
+    "user-stories",
+    "code-to-test"
+  ],
+  "produces": [
+    "test-specs",
+    "test-suite",
+    "coverage-report"
   ]
 }

--- a/agents/test-runner/agent.md
+++ b/agents/test-runner/agent.md
@@ -197,3 +197,22 @@ If tests cannot be fixed:
 4. Never leave tests in a broken state
 
 Remember: The goal is to ensure all tests pass while maintaining their original intent and coverage. Tests are documentation of expected behavior - preserve that documentation.
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "Test run complete. All tests have been executed and results are available.",
+  voice_id: "cgSgspJ2msm6clMCkdW9",
+  output_directory: "."
+)
+```
+
+Your assigned voice: Default Voice - Default Voice
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps

--- a/agents/test-runner/metadata.json
+++ b/agents/test-runner/metadata.json
@@ -3,15 +3,47 @@
   "version": "1.0.0",
   "description": "Automated test execution specialist that runs tests and fixes failures",
   "author": "Claude Sub-Agents",
-  "tags": ["testing", "automation", "quality-assurance", "ci-cd"],
+  "tags": [
+    "testing",
+    "automation",
+    "quality-assurance",
+    "ci-cd"
+  ],
   "requirements": {
-    "tools": ["Bash", "Read", "Edit", "Grep", "Glob"],
-    "optional_tools": ["MultiEdit"]
+    "tools": [
+      "Bash",
+      "Read",
+      "Edit",
+      "Grep",
+      "Glob"
+    ],
+    "optional_tools": [
+      "MultiEdit"
+    ]
   },
   "hooks": {
-    "recommended": ["Stop", "PostToolUse:Edit"],
-    "optional": ["PreToolUse:Bash"]
+    "recommended": [
+      "Stop",
+      "PostToolUse:Edit"
+    ],
+    "optional": [
+      "PreToolUse:Bash"
+    ]
   },
-  "commands": ["test"],
-  "compatible_with": ["claude-code@>=1.0.0"]
+  "commands": [
+    "test"
+  ],
+  "compatible_with": [
+    "claude-code@>=1.0.0"
+  ],
+  "consumes": [
+    "test-suite",
+    "codebase",
+    "test-specs"
+  ],
+  "produces": [
+    "test-results",
+    "coverage-report",
+    "failing-tests"
+  ]
 }

--- a/agents/work-completion-summary/agent.md
+++ b/agents/work-completion-summary/agent.md
@@ -1,0 +1,56 @@
+---
+name: work-completion-summary
+description: Proactively triggered when work is completed to provide concise audio summaries and suggest next steps. If they say 'tts' or 'tts summary' or 'audio summary' use this agent. When you prompt this agent, describe exactly what you want them to communicate to the user. Remember, this agent has no context about any questions or previous conversations between you and the user. So be sure to communicate well so they can respond to the user. Be concise, and to the point - aim for 2 sentences max.
+tools: Bash, mcp__ElevenLabs__text_to_speech, mcp__ElevenLabs__play_audio
+memory: agent:work-completion-summary:summaries
+color: Green
+---
+
+# Purpose
+
+You are a work completion summarizer that creates extremely concise audio summaries when tasks are finished. You convert achievements into brief spoken feedback that helps maintain momentum.
+
+## Variables
+
+USER_NAME: "${ENGINEER_NAME:-User}"
+
+## Instructions
+
+When invoked after work completion, you must follow these steps:
+
+1. IMPORTANT: **Analyze completed work**: Review the user prompt given to you to create a concise natural language summary of what was done limit to 1 sentence max.
+2. IMPORTANT: **Create ultra-concise summary**: Craft a concise 1 sentence maximum summary of what was done (no introductions, no filler)
+3. **Suggest next steps**: Add concise 1 logical next actions in equally concise format
+4. **Generate audio**:
+   - Use `mcp__ElevenLabs__text_to_speech` with appropriate voice
+   - Get current directory with `pwd` command
+   - Save to absolute path: `{current_directory}/output/work-summary-{timestamp}.mp3`
+   - Create output directory if it doesn't exist
+5. **Play audio**: Use `mcp__ElevenLabs__play_audio` to automatically play the generated summary
+
+**Best Practices:**
+- Be ruthlessly concise - every word must add value
+- Focus only on what was accomplished and immediate next steps
+- Use natural, conversational tone suitable for audio
+- No pleasantries or introductions - get straight to the point
+- Ensure output directory exists before generating audio
+- Use timestamp in filename to avoid conflicts
+- IMPORTANT: Run only bash: 'pwd', 'mkdir', and the eleven labs mcp tools. Do not use any other tools. Base your summary on the user prompt given to you.
+
+## Report / Response
+
+Your response should include:
+- The text of your audio summary
+- Confirmation that audio was generated and played
+- File path where audio was saved
+
+## Example Summaries
+
+Good examples:
+- "Documentation created. Next: add API examples."
+- "Tests passing. Ready for deployment."
+- "UI components built. Consider adding animations."
+
+Bad examples (too long/verbose):
+- "I have successfully completed the documentation task you requested. The next logical step would be to add some API examples."
+- "Hello! I'm happy to report that all tests are now passing successfully."

--- a/agents/work-completion-summary/metadata.json
+++ b/agents/work-completion-summary/metadata.json
@@ -1,0 +1,35 @@
+{
+  "name": "work-completion-summary",
+  "version": "1.0.0",
+  "description": "Creates concise spoken audio summaries when work is completed and suggests next steps",
+  "author": "Claude Sub-Agents",
+  "tags": ["voice", "tts", "summary", "completion", "elevenlabs"],
+  "requirements": {
+    "tools": ["Bash", "mcp__ElevenLabs__text_to_speech", "mcp__ElevenLabs__play_audio"],
+    "optional_tools": []
+  },
+  "capabilities": [
+    "audio_summaries",
+    "completion_announcements",
+    "next_step_suggestions"
+  ],
+  "triggers": {
+    "keywords": ["tts", "tts summary", "audio summary", "completion summary"],
+    "patterns": ["summarize * completion", "announce * done"]
+  },
+  "hooks": {
+    "recommended": ["SubagentStop", "Stop"],
+    "optional": []
+  },
+  "commands": ["voice"],
+  "compatible_with": ["claude-code@>=1.0.0"],
+  "consumes": ["task-result", "completion-message"],
+  "produces": ["audio-summary", "spoken-announcement"],
+  "examples": [
+    {
+      "trigger": "Work completed",
+      "request": "Give an audio summary of what was just finished",
+      "response": "I'll create a brief spoken summary of the completed work and suggest next steps"
+    }
+  ]
+}

--- a/commands/meta.md
+++ b/commands/meta.md
@@ -1,0 +1,1 @@
+Use the meta-agent to create a new sub-agent: $ARGUMENTS

--- a/docs/AGENT-CHAINING.md
+++ b/docs/AGENT-CHAINING.md
@@ -1,0 +1,203 @@
+# Agent Chaining System
+
+The claude-agents chaining system enables powerful workflows by allowing agents to pass data to each other while preserving context windows.
+
+## Overview
+
+Agent chaining allows you to:
+- Run multiple agents in sequence
+- Pass outputs from one agent as inputs to another
+- Execute agents concurrently when appropriate
+- Keep orchestrator context clean
+
+## How It Works
+
+1. **Memory-Based Handoffs**: Agents communicate through the memory system
+2. **Lightweight Data**: Only essential data is passed between agents
+3. **Type Matching**: Agent outputs are matched to inputs by type
+4. **Context Preservation**: Each agent runs in isolation
+
+## Using Agent Chains
+
+### Ad-Hoc Chaining
+
+Run agents sequentially with custom tasks:
+
+```bash
+# Simple sequential chain
+claude-agents chain api-developer frontend-developer --task "Build user auth"
+
+# With individual tasks
+claude-agents chain debugger api-developer test-runner \
+  --tasks "Find login bug" "Fix the issue" "Verify fix"
+
+# With voice announcements
+claude-agents chain code-reviewer refactor --voice
+```
+
+### Predefined Chains
+
+Use pre-built chain templates:
+
+```bash
+# Run a predefined chain
+claude-agents chain feature-development
+
+# Available chains:
+- feature-development  # Full development pipeline
+- bug-fix             # Debug and fix issues
+- api-optimization    # Performance improvements
+- security-audit      # Security scanning and fixes
+```
+
+### Creating Custom Chains
+
+Save chains in `.claude/chains/my-chain.json`:
+
+```json
+{
+  "name": "my-custom-chain",
+  "description": "Description of what this chain does",
+  "steps": [
+    {
+      "agent": "project-planner",
+      "task": "Plan the implementation",
+      "outputs": ["technical-plan"]
+    },
+    {
+      "agent": "api-developer",
+      "task": "Build according to plan",
+      "inputs": ["technical-plan"],
+      "outputs": ["api-implementation"]
+    }
+  ]
+}
+```
+
+## Agent Input/Output Types
+
+Each agent declares what it consumes and produces:
+
+| Agent | Consumes | Produces |
+|-------|----------|----------|
+| project-planner | requirements, user-stories | technical-plan, task-breakdown |
+| api-developer | technical-plan, bug-report | api-implementation, endpoints |
+| frontend-developer | endpoints, user-stories | ui-implementation, ui-components |
+| test-runner | test-suite, codebase | test-results, failing-tests |
+| code-reviewer | code-changes, implementation | review-report, improvement-list |
+| debugger | error-report, failing-tests | root-cause, fix-strategy |
+
+## Concurrent Execution
+
+Run agents in parallel when they don't depend on each other:
+
+```json
+{
+  "steps": [
+    {
+      "agent": "code-reviewer",
+      "task": "Review code",
+      "concurrent": true
+    },
+    {
+      "agent": "security-scanner",
+      "task": "Scan for vulnerabilities",
+      "concurrent": true
+    },
+    {
+      "agent": "test-runner",
+      "task": "Run tests",
+      "concurrent": true
+    }
+  ]
+}
+```
+
+## Best Practices
+
+1. **Keep Handoffs Small**: Pass only essential data
+2. **Use Type Matching**: Ensure outputs match expected inputs
+3. **Clear Task Descriptions**: Be specific about what each agent should do
+4. **Test Chains**: Verify chains work before saving them
+5. **Monitor Memory**: Check handoffs with `memory.keys("handoff:*:*:*")`
+
+## Example: Feature Development
+
+```bash
+# 1. Create user stories
+claude-agents run product-manager --task "Define checkout feature"
+
+# 2. Plan implementation
+claude-agents run project-planner --task "Plan checkout implementation"
+
+# 3. Or use the chain
+claude-agents chain feature-development --task "checkout feature"
+```
+
+The chain will:
+1. Product manager creates user stories
+2. Project planner creates technical plan
+3. TDD specialist writes tests
+4. API developer implements backend
+5. Frontend developer builds UI
+6. Test runner verifies everything
+7. Code reviewer ensures quality
+
+## Meta-Agent Integration
+
+When you need a specialized agent that doesn't exist:
+
+```bash
+# The meta-agent can create new agents on demand
+claude-agents chain meta-agent api-developer \
+  --tasks "Create a GraphQL specialist agent" "Use it to build GraphQL API"
+```
+
+## Viewing Handoffs
+
+Check what data is being passed:
+
+```bash
+# In your project
+node -e "
+const memory = require('./node_modules/@webdevtoday/claude-agents/src/memory').getMemoryStore();
+console.log(memory.keys('handoff:*:*:*'));
+"
+```
+
+## Troubleshooting
+
+- **Missing inputs**: Check agent metadata for required inputs
+- **Large context**: Reduce data in handoffs
+- **Chain fails**: Run agents individually to debug
+- **No handoff**: Verify agent produces expected output type
+
+## Advanced Usage
+
+### Dynamic Chains
+
+Create chains based on conditions:
+
+```javascript
+// In your code
+import { chainCommand } from '@webdevtoday/claude-agents';
+
+const agents = condition ? ['debugger', 'api-developer'] : ['code-reviewer', 'refactor'];
+await chainCommand(agents, { task: 'Handle based on condition' });
+```
+
+### Custom Handoff Logic
+
+Agents can implement custom handoff logic:
+
+```javascript
+// In agent implementation
+if (produces.includes('api-endpoints')) {
+  createHandoff(agentName, 'frontend-developer', 'endpoints', {
+    paths: ['/api/users', '/api/products'],
+    methods: ['GET', 'POST']
+  }, 'Created 2 REST endpoints');
+}
+```
+
+The chaining system enables powerful multi-agent workflows while keeping each agent focused and the orchestrator's context clean!

--- a/docs/HYBRID_ORCHESTRATION_PLAN.md
+++ b/docs/HYBRID_ORCHESTRATION_PLAN.md
@@ -1,0 +1,338 @@
+# 🚀 Hybrid Orchestration System - Complete Integration Plan
+
+## Executive Summary
+
+Transform the sub-agents system into an intelligent, self-orchestrating platform that automatically spawns appropriate agents while maintaining manual control options. This hybrid approach combines the best of both worlds: automatic assistance and explicit control.
+
+## Phase 1: Orchestrator Foundation (Week 1)
+
+### 1.1 Hook System Implementation
+```
+.claude/
+├── settings.json              # Hook configuration
+├── hooks/
+│   ├── orchestrator.js        # ✅ Prompt analyzer
+│   ├── task-interceptor.js    # Task() call interceptor
+│   ├── agent-coordinator.js   # Concurrent execution manager
+│   └── voice-announcer.js     # TTS integration
+└── logs/
+    ├── orchestrator.log       # Decision logs
+    └── agent-execution.log    # Execution history
+```
+
+### 1.2 Orchestrator Components
+
+#### A. Prompt Analyzer (orchestrator.js)
+```javascript
+// Analyzes user prompts and injects agent suggestions
+- Pattern matching with scoring system
+- Context awareness (file types, keywords, project state)
+- Outputs agent recommendations to Claude
+```
+
+#### B. Task Interceptor (task-interceptor.js)
+```javascript
+// Intercepts Task() tool calls to spawn sub-agents
+- Detects when Claude uses Task()
+- Analyzes task description
+- Automatically spawns relevant sub-agents
+- Manages concurrent execution
+```
+
+#### C. Agent Coordinator (agent-coordinator.js)
+```javascript
+// Manages concurrent agent execution
+- Spawn multiple agents in parallel
+- Track agent status
+- Aggregate results
+- Handle dependencies
+```
+
+## Phase 2: Voice Integration (Week 2)
+
+### 2.1 TTS System Architecture
+```
+src/
+└── utils/
+    └── tts/
+        ├── index.js           # TTS orchestrator
+        ├── providers/
+        │   ├── elevenlabs.js  # ElevenLabs API
+        │   ├── openai.js      # OpenAI TTS
+        │   └── local.js       # pyttsx3 fallback
+        └── config.js          # API key management
+```
+
+### 2.2 Voice Integration Points
+- **Agent Start**: "Starting code review analysis..."
+- **Agent Complete**: "Code review complete. 3 issues found."
+- **Error Alerts**: "Test runner encountered an error..."
+- **Task Progress**: "API documentation generated successfully."
+
+### 2.3 Configuration
+```json
+// ~/.claude-agents/config.json
+{
+  "voice": {
+    "enabled": true,
+    "provider": "auto", // auto, elevenlabs, openai, local
+    "announcements": {
+      "agentStart": true,
+      "agentComplete": true,
+      "errors": true,
+      "progress": false
+    }
+  },
+  "api_keys": {
+    "elevenlabs": "...",
+    "openai": "..."
+  }
+}
+```
+
+## Phase 3: Meta-Agent Integration (Week 2)
+
+### 3.1 Meta-Agent Implementation
+```
+agents/
+└── meta-agent/
+    ├── agent.md          # Agent generator specialist
+    ├── metadata.json     # Configuration
+    └── templates/        # Agent templates
+        ├── basic.md
+        ├── reviewer.md
+        └── developer.md
+```
+
+### 3.2 Meta-Agent Features
+- Fetches latest Claude Code documentation
+- Generates properly formatted agents
+- Suggests optimal tool configurations
+- Creates both simple and complex agents
+
+## Phase 4: Enhanced CLAUDE.md Rules (Week 3)
+
+### 4.1 Orchestration Rules
+```markdown
+# Intelligent Orchestration System
+
+## Your Role as Orchestrator
+You are an intelligent task orchestrator. Your primary responsibility is to:
+1. Analyze every user request for opportunities to use specialized agents
+2. Spawn multiple agents concurrently when beneficial
+3. Synthesize results from multiple agents into cohesive responses
+4. Proactively suggest agent usage without being asked
+
+## Automatic Agent Patterns
+
+### Development Tasks
+- "implement..." → project-planner + api-developer/frontend-developer
+- "fix..." → debugger + test-runner
+- "refactor..." → refactor + code-reviewer
+- "document..." → doc-writer + api-documenter
+
+### Quality Tasks
+- "review..." → code-reviewer + security-scanner
+- "test..." → test-runner + tdd-specialist
+- "optimize..." → refactor + code-reviewer
+
+### Complex Tasks
+When a task involves multiple aspects, spawn agents concurrently:
+
+Task("project-planner: Break down e-commerce platform requirements")
+Task("api-developer: Design REST API structure")
+Task("frontend-developer: Plan React component architecture")
+Task("tdd-specialist: Create testing strategy")
+
+## Concurrent Execution Rules
+
+MANDATORY: Always execute related operations in parallel:
+- Multiple file reads/writes
+- Independent agent tasks
+- Test + lint + build operations
+
+Example of CORRECT concurrent execution:
+[Single Message]:
+  Task("code-reviewer: Review authentication module")
+  Task("security-scanner: Check for vulnerabilities")
+  Task("test-runner: Run auth tests")
+  Read("src/auth/login.js")
+  Read("src/auth/register.js")
+```
+
+## Phase 5: CLI Enhancements (Week 3)
+
+### 5.1 New CLI Commands
+```bash
+# Enable/disable auto-orchestration
+claude-agents orchestrate --enable
+claude-agents orchestrate --disable
+
+# Configure voice
+claude-agents voice --enable
+claude-agents voice --provider elevenlabs
+claude-agents voice --test "Hello, testing voice"
+
+# View orchestration logs
+claude-agents logs --orchestration
+claude-agents logs --agent-execution
+
+# Meta-agent usage
+claude-agents create --auto  # Uses meta-agent
+```
+
+### 5.2 Interactive Dashboard Updates
+- Real-time orchestration view
+- Agent dependency graph
+- Voice status indicator
+- Concurrent execution metrics
+
+## Phase 6: Integration Patterns (Week 4)
+
+### 6.1 Hybrid Usage Examples
+
+#### Automatic Mode (Default)
+```
+User: "Create a user authentication system with tests"
+
+Claude (with orchestration):
+I'll help you create a user authentication system. I'm coordinating with several specialized agents to handle different aspects:
+
+[Spawns concurrently]:
+- project-planner: System design
+- api-developer: Backend implementation  
+- frontend-developer: UI components
+- tdd-specialist: Test suite
+- security-scanner: Security review
+```
+
+#### Manual Override
+```
+User: "Just use the /review command, don't auto-orchestrate"
+
+Claude: Running code review only as requested.
+/review
+```
+
+#### Mixed Mode
+```
+User: "Review my code and fix any issues you find"
+
+Claude: I'll review your code and coordinate with other agents for fixes:
+/review
+[Auto-spawns]: debugger, refactor (if issues found)
+```
+
+### 6.2 Task Interception Examples
+
+When Claude uses Task():
+```javascript
+// Original Task
+Task("Implement user authentication")
+
+// Orchestrator intercepts and enhances:
+Task("api-developer: Implement auth endpoints")
+Task("frontend-developer: Create login/register forms")
+Task("tdd-specialist: Write auth tests")
+Task("security-scanner: Verify auth security")
+```
+
+## Implementation Timeline
+
+### Week 1: Foundation
+- [x] Basic orchestrator hook
+- [ ] Task interceptor
+- [ ] Agent coordinator
+- [ ] Update CLAUDE.md with orchestration rules
+
+### Week 2: Voice & Meta-Agent
+- [ ] TTS system implementation
+- [ ] Voice configuration
+- [ ] Meta-agent integration
+- [ ] Meta-agent templates
+
+### Week 3: CLI & Rules
+- [ ] CLI orchestration commands
+- [ ] Enhanced CLAUDE.md rules
+- [ ] Dashboard updates
+- [ ] Logging system
+
+### Week 4: Testing & Polish
+- [ ] Integration testing
+- [ ] Performance optimization
+- [ ] Documentation
+- [ ] Example projects
+
+## Success Metrics
+
+1. **Automatic Usage**: 80% of tasks trigger appropriate agents
+2. **Performance**: 3x faster completion with concurrent execution
+3. **User Satisfaction**: Reduced cognitive load, better results
+4. **Voice Feedback**: Clear status without screen watching
+
+## Configuration Files
+
+### .claude/settings.json
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [{
+      "hooks": [{
+        "type": "command",
+        "command": "node .claude/hooks/orchestrator.js"
+      }]
+    }],
+    "PreToolUse": [{
+      "matcher": "Task",
+      "hooks": [{
+        "type": "command",
+        "command": "node .claude/hooks/task-interceptor.js"
+      }]
+    }],
+    "PostToolUse": [{
+      "matcher": "Task",
+      "hooks": [{
+        "type": "command",
+        "command": "node .claude/hooks/voice-announcer.js"
+      }]
+    }]
+  }
+}
+```
+
+### .claude-agents.json (Project Level)
+```json
+{
+  "orchestration": {
+    "enabled": true,
+    "autoSpawn": true,
+    "concurrentLimit": 5,
+    "voiceAnnouncements": true
+  },
+  "agentPreferences": {
+    "preferredReviewer": "code-reviewer",
+    "preferredTester": "test-runner",
+    "customTriggers": {
+      "deploy": ["devops-engineer", "security-scanner"]
+    }
+  }
+}
+```
+
+## Migration Path
+
+1. **Existing Users**: Orchestration disabled by default
+2. **New Users**: Orchestration enabled with onboarding
+3. **Gradual Rollout**: Feature flags for testing
+4. **Backwards Compatible**: All slash commands remain
+
+## Conclusion
+
+This hybrid orchestration system transforms Claude into an intelligent project manager that:
+- Automatically identifies when specialized help is needed
+- Spawns multiple agents concurrently for efficiency
+- Provides voice feedback for hands-free awareness
+- Maintains manual control when precision is required
+- Grows smarter with the meta-agent creating new specialists
+
+The result: A more intelligent, efficient, and user-friendly development experience that feels like having an entire development team at your command.

--- a/examples/voice-integration.md
+++ b/examples/voice-integration.md
@@ -1,0 +1,191 @@
+# Voice Integration with Sub-Agents
+
+This guide shows how to use voice announcements with Claude Sub-Agents using the ElevenLabs MCP server.
+
+## Setup
+
+### 1. Configure ElevenLabs MCP in Claude Code
+
+Run this command:
+
+```bash
+claude mcp add ElevenLabs -e ELEVENLABS_API_KEY=your-api-key -- uvx elevenlabs-mcp
+```
+
+This will automatically configure the MCP server. Alternatively, you can manually add to `settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "ElevenLabs": {
+      "command": "uvx",
+      "args": ["elevenlabs-mcp"],
+      "env": {
+        "ELEVENLABS_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+### 2. Configure Voice in Claude Agents
+
+```bash
+# Enable voice globally
+claude-agents voice --enable
+
+# Set provider to MCP
+claude-agents voice --provider mcp
+```
+
+## Usage Examples
+
+### Running Agents with Voice
+
+```bash
+# Single agent with voice announcement
+claude-agents run api-developer --task "Create user authentication endpoints" --voice
+
+# Multiple agents with voice
+claude-agents run project-planner --task "Design e-commerce platform" --voice
+claude-agents run frontend-developer --task "Build product catalog UI" --voice
+```
+
+### In Claude Code
+
+When agents complete tasks, they'll automatically call the MCP tool:
+
+```javascript
+// Agent completion announcement
+mcp__ElevenLabs__text_to_speech(
+  text: "I've finished implementing the user authentication API. All endpoints are secured with JWT tokens and tests are passing.",
+  voice_id: "21m00Tcm4TlvDq8ikWAM",
+  output_directory: "."
+)
+```
+
+## Voice Assignments
+
+Each agent has a unique voice personality:
+
+| Agent | Voice | Character |
+|-------|-------|-----------|
+| project-planner | Daniel | Clear & Professional |
+| api-developer | Rachel | Authoritative |
+| frontend-developer | Bella | Creative & Warm |
+| tdd-specialist | Antoni | Precise |
+| code-reviewer | Sam | Problem Solver |
+| debugger | Michael | Serious |
+| security-scanner | Liam | Stoic |
+| devops-engineer | Clyde | Technical |
+| shadcn-ui-builder | Elli | Engaging |
+| product-manager | Brian | Trustworthy |
+| marketing-writer | Dorothy | Business |
+
+## Advanced Usage
+
+### Custom Voice Messages
+
+Agents can customize their announcements based on results:
+
+```javascript
+// In agent code
+const message = result.errors > 0 
+  ? `I've completed the security scan and found ${result.errors} vulnerabilities that need attention.`
+  : `Security scan complete. No critical vulnerabilities found. The code is secure.`;
+
+mcp__ElevenLabs__text_to_speech(
+  text: message,
+  voice_id: "flq6f7yk4E4fJM5XTYuZ",
+  output_directory: process.cwd()
+)
+```
+
+### Concurrent Agent Announcements
+
+When running multiple agents, each will announce completion:
+
+```bash
+# All agents will announce when they complete
+claude-agents run api-developer --task "Build REST API" --voice &
+claude-agents run frontend-developer --task "Create UI" --voice &
+claude-agents run tdd-specialist --task "Write tests" --voice &
+```
+
+## Configuration Options
+
+### Voice Settings
+
+Configure which events trigger announcements:
+
+```bash
+claude-agents voice
+# Then select "View announcements settings"
+```
+
+Options:
+- Agent start announcements
+- Agent complete announcements (default: enabled)
+- Error announcements
+- Progress updates
+
+### Output Location
+
+Voice files are saved to the output directory with format:
+```
+tts_I've___20250726_113401.mp3
+```
+
+## Troubleshooting
+
+### No Voice Output?
+
+1. Check MCP server is connected in Claude Code
+2. Verify ElevenLabs API key is set
+3. Ensure voice is enabled: `claude-agents voice --enable`
+4. Check provider: `claude-agents voice --provider mcp`
+
+### Wrong Voice?
+
+Each agent has an assigned voice ID. Check `agents/[agent-name]/agent.md` for the voice_id.
+
+### API Limits?
+
+ElevenLabs has usage limits. To manage:
+- Monitor usage in your ElevenLabs dashboard
+- Use local TTS as fallback: `claude-agents voice --provider local`
+- The MCP tool will show cost warnings before making API calls
+
+## Best Practices
+
+1. **Keep announcements brief**: 2-3 sentences maximum
+2. **Be informative**: State what was done and outcomes
+3. **Suggest next steps**: Help maintain workflow momentum
+4. **Use appropriate voice**: Match voice personality to agent role
+5. **Handle errors gracefully**: Announce issues clearly
+
+## Example Workflow
+
+```bash
+# 1. Plan the project
+claude-agents run project-planner --task "Design authentication system" --voice
+# Voice: "I've completed the project planning for the authentication system..."
+
+# 2. Implement API
+claude-agents run api-developer --task "Build auth endpoints from plan" --voice
+# Voice: "I've finished implementing the authentication API endpoints..."
+
+# 3. Create UI
+claude-agents run frontend-developer --task "Build login forms" --voice
+# Voice: "I've completed the login UI. The interface is responsive..."
+
+# 4. Write tests
+claude-agents run tdd-specialist --task "Test auth flow" --voice
+# Voice: "I've written comprehensive tests for the authentication flow..."
+
+# 5. Review security
+claude-agents run security-scanner --task "Audit auth implementation" --voice
+# Voice: "I've completed the security scan. No critical vulnerabilities found..."
+```
+
+Each agent announces completion, creating an audio log of your development progress!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@webdevtoday/claude-agents",
-  "version": "1.0.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@webdevtoday/claude-agents",
-      "version": "1.0.2",
+      "version": "1.5.0",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@webdevtoday/claude-agents",
-  "version": "1.4.0",
-  "description": "AI-powered development shop with 15 specialized agents for Claude Code. Features concurrent execution, shared memory, context-forge integration, and web dashboard for 80% faster development.",
+  "version": "1.5.5",
+  "description": "AI-powered development shop with 16 specialized agents for Claude Code. Features agent chaining, voice announcements, meta-agent, concurrent execution, shared memory, context-forge integration, and web dashboard for 80% faster development.",
   "main": "src/index.js",
   "type": "module",
   "bin": {
@@ -12,6 +12,7 @@
     "bin/**/*",
     "agents/**/*",
     "commands/**/*",
+    "templates/**/*",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/add-voice-to-agents.js
+++ b/scripts/add-voice-to-agents.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+/**
+ * Script to add voice announcement instructions to all agents
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { AGENT_VOICES } from '../src/utils/voice/agent-announcements.js';
+
+const AGENTS_DIR = join(process.cwd(), 'agents');
+
+const VOICE_SECTION_TEMPLATE = `
+
+## Voice Announcements
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool:
+
+\`\`\`
+mcp__ElevenLabs__text_to_speech(
+  text: "{{COMPLETION_MESSAGE}}",
+  voice_id: "{{VOICE_ID}}",
+  output_directory: "{{OUTPUT_DIR}}"
+)
+\`\`\`
+
+Your assigned voice: {{VOICE_NAME}} - {{VOICE_DESCRIPTION}}
+
+Keep announcements concise and informative, mentioning:
+- What you completed
+- Key outcomes (tests passing, endpoints created, etc.)
+- Suggested next steps`;
+
+// Voice descriptions for each voice ID
+const VOICE_DESCRIPTIONS = {
+  'onwK4e9ZLuTAKqWW03F9': 'Daniel - Clear & Professional',
+  '21m00Tcm4TlvDq8ikWAM': 'Rachel - Authoritative',
+  '2EiwWnXFnvU5JabPnv8n': 'Clyde - Technical',
+  'EXAVITQu4vr4xnSDxMaL': 'Bella - Creative & Warm',
+  'jsCqWAovK2LkecY7zXl4': 'Elli - Engaging',
+  'ThT5KcBeYPX3keUQqHPh': 'Dorothy - Business',
+  'ErXwobaYiN019PkySvjV': 'Antoni - Precise',
+  'yoZ06aMxZJJ28mfd3POQ': 'Sam - Problem Solver',
+  'flq6f7yk4E4fJM5XTYuZ': 'Michael - Serious',
+  'TX3LPaxmHKxFdv7VOQHJ': 'Liam - Stoic',
+  'z9fAnlkpzviPz146aGWa': 'Glinda - Witch',
+  'XB0fDUnXU5powFXDhCwa': 'Charlotte - Swedish',
+  'cgSgspJ2msm6clMCkdW9': 'Default Voice',
+  'GBv7mTt0atIp3Br8iCZE': 'Thomas - Calm',
+  'nPczCjzI2devNBz1zQrb': 'Brian - Trustworthy',
+  'zrHiDhphv9ZnVXBqCLjz': 'Mimi - Playful',
+};
+
+// Example completion messages for each agent type
+const COMPLETION_MESSAGES = {
+  'project-planner': "I've completed the project planning. The roadmap is ready with clear milestones and deliverables.",
+  'api-developer': "I've finished implementing the API endpoints. All tests are passing and documentation is updated.",
+  'frontend-developer': "I've completed the UI implementation. The interface is responsive and ready for review.",
+  'tdd-specialist': "I've written comprehensive tests. All tests are passing with good coverage.",
+  'code-reviewer': "I've completed the code review. I've identified areas for improvement and security considerations.",
+  'debugger': "I've resolved the issue. The root cause has been fixed and verified.",
+  'security-scanner': "I've completed the security scan. All vulnerabilities have been documented.",
+  'devops-engineer': "I've set up the pipeline. Everything is configured and ready to use.",
+  'shadcn-ui-builder': "I've built the UI components. The interface is complete and follows design guidelines.",
+  'product-manager': "I've completed the requirements. User stories and acceptance criteria are documented.",
+  'marketing-writer': "I've written the content. Everything is ready for publication.",
+  'api-documenter': "I've documented the API. All endpoints are covered with examples.",
+  'test-runner': "Test run complete. All tests have been executed and results are available.",
+  'refactor': "I've refactored the code. The structure is improved and all tests are passing.",
+  'doc-writer': "I've written the documentation. All sections are complete and reviewed.",
+  'meta-agent': "I've created the new agent. It's ready to use with the specialized capabilities.",
+  'default': "I've completed the task. Everything is ready for the next step."
+};
+
+function addVoiceToAgent(agentDir) {
+  const agentName = agentDir;
+  const agentPath = join(AGENTS_DIR, agentDir, 'agent.md');
+  
+  try {
+    const content = readFileSync(agentPath, 'utf-8');
+    
+    // Check if voice section already exists
+    if (content.includes('## Voice Announcements')) {
+      console.log(`✓ ${agentName} already has voice announcements`);
+      return;
+    }
+    
+    // Get voice configuration for this agent
+    const voiceId = AGENT_VOICES[agentName] || AGENT_VOICES.default;
+    const voiceDescription = VOICE_DESCRIPTIONS[voiceId] || 'Default Voice';
+    const completionMessage = COMPLETION_MESSAGES[agentName] || COMPLETION_MESSAGES.default;
+    
+    // Replace placeholders in template
+    const voiceSection = VOICE_SECTION_TEMPLATE
+      .replace('{{COMPLETION_MESSAGE}}', completionMessage)
+      .replace('{{VOICE_ID}}', voiceId)
+      .replace('{{OUTPUT_DIR}}', process.cwd())
+      .replace('{{VOICE_NAME}}', voiceDescription.split(' - ')[0])
+      .replace('{{VOICE_DESCRIPTION}}', voiceDescription);
+    
+    // Append to file
+    const updatedContent = content + voiceSection;
+    writeFileSync(agentPath, updatedContent);
+    
+    console.log(`✓ Added voice announcements to ${agentName}`);
+  } catch (error) {
+    console.error(`✗ Error updating ${agentName}: ${error.message}`);
+  }
+}
+
+// Main execution
+console.log('Adding voice announcements to all agents...\n');
+
+const agentDirs = readdirSync(AGENTS_DIR, { withFileTypes: true })
+  .filter(dirent => dirent.isDirectory())
+  .map(dirent => dirent.name);
+
+agentDirs.forEach(addVoiceToAgent);
+
+console.log('\nDone! Voice announcements have been added to all agents.');
+console.log('\nAgents will now announce task completion when voice is enabled.');
+console.log('To test, run: claude-agents run <agent> --task "..." --voice');

--- a/scripts/fix-absolute-paths.py
+++ b/scripts/fix-absolute-paths.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Fix hook paths in settings.json to use absolute paths
+This resolves working directory issues in Claude Code
+"""
+
+import json
+import os
+import sys
+
+def fix_settings_paths(project_dir):
+    """Update all hook paths to absolute paths"""
+    
+    settings_path = os.path.join(project_dir, '.claude', 'settings.json')
+    
+    if not os.path.exists(settings_path):
+        print(f"❌ Error: {settings_path} not found")
+        print("💡 Run 'claude-agents init' first")
+        return False
+    
+    try:
+        with open(settings_path, 'r') as f:
+            settings = json.load(f)
+        
+        # Get absolute path to hooks directory
+        hooks_dir = os.path.join(project_dir, '.claude', 'hooks')
+        
+        # Update all hook commands to use absolute paths
+        if 'hooks' in settings:
+            for hook_type, hook_configs in settings['hooks'].items():
+                for config in hook_configs:
+                    if 'hooks' in config:
+                        for hook in config['hooks']:
+                            if 'command' in hook:
+                                # Extract hook filename from command
+                                cmd = hook['command']
+                                if '.claude/hooks/' in cmd:
+                                    # Extract filename after .claude/hooks/
+                                    parts = cmd.split('.claude/hooks/')
+                                    if len(parts) == 2:
+                                        hook_file = parts[1]
+                                        # Create absolute path command
+                                        hook['command'] = f"python3 {hooks_dir}/{hook_file}"
+                                        print(f"✅ Updated {hook_type}: {hook['command']}")
+                                elif '/backend/.claude/hooks/' in cmd:
+                                    # Fix incorrect backend paths
+                                    parts = cmd.split('/backend/.claude/hooks/')
+                                    if len(parts) == 2:
+                                        hook_file = parts[1]
+                                        hook['command'] = f"python3 {hooks_dir}/{hook_file}"
+                                        print(f"✅ Fixed {hook_type}: {hook['command']}")
+        
+        # Write back with proper formatting
+        with open(settings_path, 'w') as f:
+            json.dump(settings, f, indent=2)
+        
+        print(f"\n✨ Successfully updated {settings_path}")
+        print(f"📁 All hooks now use absolute paths from: {hooks_dir}")
+        return True
+        
+    except Exception as e:
+        print(f"❌ Error updating settings: {e}")
+        return False
+
+if __name__ == "__main__":
+    # Get project directory (current directory or first argument)
+    if len(sys.argv) > 1:
+        project_dir = sys.argv[1]
+    else:
+        project_dir = os.getcwd()
+    
+    print(f"🔧 Fixing hook paths in: {project_dir}")
+    fix_settings_paths(project_dir)

--- a/scripts/fix-hooks.sh
+++ b/scripts/fix-hooks.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Claude Agents Hook Fix Script
+# This script fixes common hook permission issues
+
+echo "🔧 Claude Agents Hook Fix Script"
+echo "================================"
+
+# Check if .claude directory exists
+if [ ! -d ".claude" ]; then
+    echo "❌ Error: .claude directory not found"
+    echo "📦 Please run 'claude-agents init' first"
+    exit 1
+fi
+
+# Fix hook permissions
+echo "🔨 Fixing hook permissions..."
+
+# Main hooks
+if [ -d ".claude/hooks" ]; then
+    chmod +x .claude/hooks/*.py 2>/dev/null
+    echo "✅ Fixed main hook permissions"
+else
+    echo "❌ .claude/hooks directory not found"
+fi
+
+# LLM utilities
+if [ -d ".claude/hooks/utils/llm" ]; then
+    chmod +x .claude/hooks/utils/llm/*.py 2>/dev/null
+    echo "✅ Fixed LLM utility permissions"
+fi
+
+# TTS utilities
+if [ -d ".claude/hooks/utils/tts" ]; then
+    chmod +x .claude/hooks/utils/tts/*.py 2>/dev/null
+    echo "✅ Fixed TTS utility permissions"
+fi
+
+# Check if hooks exist
+echo ""
+echo "📋 Checking essential hooks..."
+
+HOOKS=("stop.py" "subagent_stop.py" "post_tool_use_elevenlabs.py" "notification.py")
+MISSING=0
+
+for hook in "${HOOKS[@]}"; do
+    if [ -f ".claude/hooks/$hook" ]; then
+        echo "✅ $hook found"
+    else
+        echo "❌ $hook missing"
+        MISSING=$((MISSING + 1))
+    fi
+done
+
+if [ $MISSING -gt 0 ]; then
+    echo ""
+    echo "⚠️  Warning: $MISSING hooks are missing"
+    echo "🔧 Run 'claude-agents init' to restore missing hooks"
+else
+    echo ""
+    echo "✨ All hooks are properly configured!"
+fi
+
+echo ""
+echo "💡 If you still have issues, run:"
+echo "   claude-agents diagnose"

--- a/scripts/fix-uv-paths.sh
+++ b/scripts/fix-uv-paths.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Fix UV path issues by updating settings.json to use direct Python execution
+
+echo "🔧 Fixing hook execution paths..."
+
+if [ ! -f ".claude/settings.json" ]; then
+    echo "❌ Error: .claude/settings.json not found"
+    exit 1
+fi
+
+# Create a backup
+cp .claude/settings.json .claude/settings.json.backup
+
+# Update the settings.json to use python3 directly instead of uv run
+sed -i.tmp 's/"uv run \.claude/"python3 .claude/g' .claude/settings.json
+
+# Remove temp file
+rm -f .claude/settings.json.tmp
+
+echo "✅ Updated hook commands to use python3 directly"
+echo "📋 Backup saved to .claude/settings.json.backup"
+echo ""
+echo "💡 If you still have issues, try:"
+echo "   1. which python3"
+echo "   2. which uv"
+echo "   3. claude-agents diagnose"

--- a/scripts/update-agent-io.js
+++ b/scripts/update-agent-io.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+/**
+ * Update all agents with consumes/produces metadata
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+const AGENTS_DIR = join(process.cwd(), 'agents');
+
+// Define input/output mappings for each agent
+const AGENT_IO_MAP = {
+  'project-planner': {
+    consumes: ['requirements', 'user-stories', 'project-brief'],
+    produces: ['technical-plan', 'task-breakdown', 'milestones', 'dependencies']
+  },
+  'product-manager': {
+    consumes: ['project-brief', 'market-research', 'user-feedback'],
+    produces: ['user-stories', 'requirements', 'acceptance-criteria', 'product-specs']
+  },
+  'api-developer': {
+    consumes: ['technical-plan', 'api-specs', 'test-specs', 'bug-report'],
+    produces: ['api-implementation', 'endpoints', 'api-code']
+  },
+  'frontend-developer': {
+    consumes: ['api-endpoints', 'ui-mockups', 'user-stories', 'components'],
+    produces: ['ui-implementation', 'ui-components', 'frontend-code']
+  },
+  'tdd-specialist': {
+    consumes: ['technical-plan', 'api-specs', 'user-stories', 'code-to-test'],
+    produces: ['test-specs', 'test-suite', 'coverage-report']
+  },
+  'code-reviewer': {
+    consumes: ['code-changes', 'pull-request', 'implementation'],
+    produces: ['review-report', 'improvement-list', 'security-issues']
+  },
+  'security-scanner': {
+    consumes: ['codebase', 'api-implementation', 'deployment-config'],
+    produces: ['vulnerability-report', 'security-issues', 'compliance-report']
+  },
+  'test-runner': {
+    consumes: ['test-suite', 'codebase', 'test-specs'],
+    produces: ['test-results', 'coverage-report', 'failing-tests']
+  },
+  'debugger': {
+    consumes: ['error-report', 'failing-tests', 'bug-report'],
+    produces: ['root-cause', 'fix-strategy', 'debug-analysis']
+  },
+  'refactor': {
+    consumes: ['code-issues', 'improvement-list', 'codebase'],
+    produces: ['refactored-code', 'improvement-report', 'code-changes']
+  },
+  'devops-engineer': {
+    consumes: ['deployment-specs', 'infrastructure-requirements', 'security-report'],
+    produces: ['deployment-config', 'ci-cd-pipeline', 'infrastructure-code']
+  },
+  'doc-writer': {
+    consumes: ['technical-specs', 'api-documentation', 'codebase'],
+    produces: ['user-guides', 'technical-docs', 'readme-files']
+  },
+  'api-documenter': {
+    consumes: ['api-implementation', 'endpoints', 'api-code'],
+    produces: ['api-documentation', 'openapi-spec', 'api-examples']
+  },
+  'marketing-writer': {
+    consumes: ['product-specs', 'user-guides', 'feature-list'],
+    produces: ['marketing-content', 'landing-page', 'blog-posts']
+  },
+  'shadcn-ui-builder': {
+    consumes: ['ui-requirements', 'design-system', 'component-list'],
+    produces: ['ui-components', 'component-library', 'shadcn-config']
+  },
+  'meta-agent': {
+    consumes: ['agent-requirements', 'capability-gap'],
+    produces: ['new-agent', 'agent-config']
+  }
+};
+
+// Update each agent's metadata
+Object.entries(AGENT_IO_MAP).forEach(([agentName, io]) => {
+  try {
+    const metadataPath = join(AGENTS_DIR, agentName, 'metadata.json');
+    const metadata = JSON.parse(readFileSync(metadataPath, 'utf-8'));
+    
+    // Check if already has consumes/produces
+    if (metadata.consumes && metadata.produces) {
+      console.log(`✓ ${agentName} already has I/O metadata`);
+      return;
+    }
+    
+    // Add consumes/produces
+    metadata.consumes = io.consumes;
+    metadata.produces = io.produces;
+    
+    // Write back
+    writeFileSync(metadataPath, JSON.stringify(metadata, null, 2) + '\n');
+    console.log(`✓ Updated ${agentName} with I/O metadata`);
+  } catch (error) {
+    console.error(`✗ Error updating ${agentName}: ${error.message}`);
+  }
+});
+
+console.log('\nAgent I/O metadata update complete!');

--- a/scripts/update-hook-paths.py
+++ b/scripts/update-hook-paths.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Update hook paths in settings.json to use absolute paths
+This fixes issues where Claude Code can't find hooks when working directory changes
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+def update_settings_paths(settings_path):
+    """Update hook paths to absolute paths"""
+    
+    if not os.path.exists(settings_path):
+        print(f"❌ Error: {settings_path} not found")
+        return False
+    
+    project_dir = Path(settings_path).parent.parent
+    
+    try:
+        with open(settings_path, 'r') as f:
+            settings = json.load(f)
+        
+        # Update hook commands to use absolute paths
+        if 'hooks' in settings:
+            for hook_type, hook_configs in settings['hooks'].items():
+                for config in hook_configs:
+                    if 'hooks' in config:
+                        for hook in config['hooks']:
+                            if 'command' in hook and '.claude/hooks/' in hook['command']:
+                                # Extract the hook filename
+                                parts = hook['command'].split('.claude/hooks/')
+                                if len(parts) == 2:
+                                    hook_file = parts[1]
+                                    # Create absolute path
+                                    abs_path = project_dir / '.claude' / 'hooks' / hook_file
+                                    hook['command'] = f"uv run {abs_path}"
+                                    print(f"✅ Updated {hook_type} hook to use absolute path")
+        
+        # Write back
+        with open(settings_path, 'w') as f:
+            json.dump(settings, f, indent=2)
+        
+        print(f"✨ Successfully updated {settings_path}")
+        return True
+        
+    except Exception as e:
+        print(f"❌ Error updating settings: {e}")
+        return False
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        settings_file = sys.argv[1]
+    else:
+        # Default to current directory
+        settings_file = ".claude/settings.json"
+    
+    update_settings_paths(settings_file)

--- a/src/commands/chain.js
+++ b/src/commands/chain.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+import chalk from 'chalk';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import ora from 'ora';
+import { loadConfig, getVoiceConfig } from '../utils/config.js';
+import { getMemoryStore } from '../memory/index.js';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export async function chainCommand(chainNameOrAgents, options) {
+  const spinner = ora();
+  const memory = getMemoryStore();
+  const voiceConfig = getVoiceConfig();
+  const useVoice = options.voice !== undefined ? options.voice : voiceConfig.enabled;
+  
+  try {
+    console.log(chalk.bold.blue('🔗 Agent Chain Execution\n'));
+    
+    let chain;
+    
+    // Check if it's a predefined chain or ad-hoc agents
+    if (chainNameOrAgents.length === 1 && !chainNameOrAgents[0].includes(',')) {
+      // Try to load predefined chain
+      const chainPath = join(process.cwd(), '.claude', 'chains', `${chainNameOrAgents[0]}.json`);
+      
+      if (existsSync(chainPath)) {
+        chain = JSON.parse(readFileSync(chainPath, 'utf-8'));
+        console.log(chalk.cyan(`Loading chain: ${chain.name}`));
+        console.log(chalk.gray(chain.description));
+        console.log();
+      } else {
+        // List available chains
+        const chainsDir = join(process.cwd(), '.claude', 'chains');
+        if (existsSync(chainsDir)) {
+          const chains = readdirSync(chainsDir)
+            .filter(f => f.endsWith('.json'))
+            .map(f => f.replace('.json', ''));
+          
+          if (chains.length > 0) {
+            console.error(chalk.red(`Chain "${chainNameOrAgents[0]}" not found.\n`));
+            console.log(chalk.yellow('Available chains:'));
+            chains.forEach(c => console.log(chalk.gray('  -'), c));
+          } else {
+            console.error(chalk.red('No predefined chains found.'));
+          }
+        } else {
+          console.error(chalk.red('No chains directory found.'));
+        }
+        process.exit(1);
+      }
+    } else {
+      // Ad-hoc chain from command line
+      const agents = chainNameOrAgents.join(',').split(',').map(a => a.trim());
+      chain = {
+        name: 'ad-hoc-chain',
+        description: `Running ${agents.length} agents sequentially`,
+        steps: agents.map((agent, i) => ({
+          agent,
+          task: options.tasks?.[i] || options.task || `Task for ${agent}`
+        }))
+      };
+    }
+    
+    // Display chain plan
+    console.log(chalk.bold('📋 Chain Plan:'));
+    chain.steps.forEach((step, i) => {
+      const prefix = i === chain.steps.length - 1 ? '└─' : '├─';
+      console.log(chalk.gray(prefix), `${i + 1}.`, chalk.cyan(step.agent), '→', chalk.yellow(step.task));
+    });
+    console.log();
+    
+    // Execute chain
+    const results = [];
+    const startTime = Date.now();
+    
+    for (let i = 0; i < chain.steps.length; i++) {
+      const step = chain.steps[i];
+      const stepNum = i + 1;
+      
+      console.log(chalk.bold(`\n🚀 Step ${stepNum}/${chain.steps.length}: ${step.agent}`));
+      console.log(chalk.gray('─'.repeat(50)));
+      
+      // Check if we should run concurrently
+      if (step.concurrent && i < chain.steps.length - 1) {
+        // Run this and next steps concurrently
+        const concurrentSteps = [step];
+        while (i + 1 < chain.steps.length && chain.steps[i + 1].concurrent) {
+          i++;
+          concurrentSteps.push(chain.steps[i]);
+        }
+        
+        console.log(chalk.yellow('Running concurrently:'));
+        concurrentSteps.forEach(s => console.log(chalk.gray('  •'), s.agent));
+        
+        // Execute concurrent steps
+        const promises = concurrentSteps.map(s => executeAgent(s.agent, s.task, options));
+        const concurrentResults = await Promise.all(promises);
+        results.push(...concurrentResults);
+      } else {
+        // Execute single step
+        const result = await executeAgent(step.agent, step.task, options);
+        results.push(result);
+      }
+      
+      // Small delay between steps
+      if (i < chain.steps.length - 1) {
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
+    }
+    
+    // Summary
+    const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+    console.log(chalk.bold.green(`\n✅ Chain Completed in ${duration}s`));
+    
+    // Show handoffs created
+    const handoffPattern = 'handoff:*:*:*';
+    const handoffs = memory.keys(handoffPattern);
+    
+    if (handoffs.length > 0) {
+      console.log(chalk.bold('\n📦 Handoffs Created:'));
+      handoffs.slice(-5).forEach(key => {
+        const handoff = memory.get(key);
+        if (handoff) {
+          console.log(chalk.gray('├─'), 
+            chalk.cyan(handoff.from), '→', 
+            chalk.yellow(handoff.type), '→',
+            chalk.green(handoff.to === '*' ? 'any' : handoff.to)
+          );
+        }
+      });
+    }
+    
+    // Tips
+    console.log('\n' + chalk.bold('💡 Next Steps:'));
+    console.log(chalk.gray('•'), 'View handoffs:', chalk.yellow('memory.keys("handoff:*:*:*")'));
+    console.log(chalk.gray('•'), 'Create chain file:', chalk.yellow('claude-agents chain --save my-chain'));
+    console.log(chalk.gray('•'), 'Run with voice:', chalk.yellow('claude-agents chain my-chain --voice'));
+    
+  } catch (error) {
+    spinner.fail('Chain execution failed');
+    console.error(chalk.red(error.message));
+    if (error.stack && process.env.DEBUG) {
+      console.error(chalk.gray(error.stack));
+    }
+    process.exit(1);
+  }
+}
+
+async function executeAgent(agentName, task, options) {
+  return new Promise((resolve, reject) => {
+    const args = ['run', agentName, '--task', task];
+    
+    if (options.voice) {
+      args.push('--voice');
+    }
+    
+    if (options.isolated) {
+      args.push('--isolated');
+    }
+    
+    const child = spawn('claude-agents', args, {
+      stdio: 'inherit',
+      shell: true
+    });
+    
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ agent: agentName, task, status: 'completed' });
+      } else {
+        reject(new Error(`Agent ${agentName} failed with code ${code}`));
+      }
+    });
+    
+    child.on('error', (err) => {
+      reject(err);
+    });
+  });
+}

--- a/src/commands/cleanup.js
+++ b/src/commands/cleanup.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/**
+ * Cleanup old TTS audio files
+ */
+
+import { program } from 'commander';
+import { cleanupOldVoiceFiles } from '../utils/voice/cleanup.js';
+import chalk from 'chalk';
+
+program
+  .description('Clean up old TTS audio files')
+  .option('-d, --directory <path>', 'Directory to clean', process.cwd())
+  .option('-a, --age <hours>', 'Maximum age in hours', '1')
+  .option('--dry-run', 'Show what would be deleted without actually deleting')
+  .action(async (options) => {
+    const maxAgeMs = parseFloat(options.age) * 3600000; // Convert hours to milliseconds
+    
+    console.log(chalk.cyan(`🧹 Cleaning up TTS files older than ${options.age} hours...`));
+    console.log(chalk.gray(`Directory: ${options.directory}`));
+    
+    if (options.dryRun) {
+      console.log(chalk.yellow('(Dry run - no files will be deleted)'));
+    }
+    
+    const result = await cleanupOldVoiceFiles(options.directory, maxAgeMs, options.dryRun);
+    
+    if (result.error) {
+      console.error(chalk.red(`Error: ${result.error}`));
+      process.exit(1);
+    }
+    
+    if (result.cleaned === 0) {
+      console.log(chalk.green('✓ No old TTS files to clean'));
+    } else {
+      console.log(chalk.green(`✓ ${options.dryRun ? 'Would clean' : 'Cleaned'} ${result.cleaned} files:`));
+      result.files.forEach(file => {
+        console.log(chalk.gray(`  - ${file}`));
+      });
+    }
+  });
+
+program.parse(process.argv);

--- a/src/commands/diagnose.js
+++ b/src/commands/diagnose.js
@@ -1,0 +1,135 @@
+import chalk from 'chalk';
+import { existsSync, statSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { execSync } from 'child_process';
+import { CLAUDE_PROJECT_DIR } from '../utils/paths.js';
+
+export async function diagnoseCommand() {
+  console.log(chalk.bold.cyan('\n🔍 Claude Agents Diagnostic Tool\n'));
+  
+  let issues = 0;
+  let warnings = 0;
+  
+  // Check if .claude directory exists
+  if (!existsSync(CLAUDE_PROJECT_DIR)) {
+    console.log(chalk.red('✗ .claude directory not found'));
+    console.log(chalk.gray('  Fix: Run ') + chalk.cyan('claude-agents init'));
+    issues++;
+    return;
+  }
+  
+  console.log(chalk.green('✓ .claude directory found'));
+  
+  // Check hooks directory
+  const hooksDir = join(CLAUDE_PROJECT_DIR, 'hooks');
+  if (!existsSync(hooksDir)) {
+    console.log(chalk.red('✗ .claude/hooks directory not found'));
+    console.log(chalk.gray('  Fix: Run ') + chalk.cyan('claude-agents init'));
+    issues++;
+  } else {
+    console.log(chalk.green('✓ .claude/hooks directory found'));
+    
+    // Check essential hooks
+    const essentialHooks = [
+      'stop.py',
+      'subagent_stop.py',
+      'post_tool_use_elevenlabs.py',
+      'notification.py'
+    ];
+    
+    console.log(chalk.bold('\nChecking essential hooks:'));
+    for (const hook of essentialHooks) {
+      const hookPath = join(hooksDir, hook);
+      if (!existsSync(hookPath)) {
+        console.log(chalk.red(`✗ ${hook} not found`));
+        issues++;
+      } else {
+        const stats = statSync(hookPath);
+        const isExecutable = (stats.mode & parseInt('111', 8)) !== 0;
+        if (!isExecutable) {
+          console.log(chalk.yellow(`⚠ ${hook} not executable`));
+          console.log(chalk.gray(`  Fix: chmod +x ${hookPath}`));
+          warnings++;
+        } else {
+          console.log(chalk.green(`✓ ${hook} found and executable`));
+        }
+      }
+    }
+  }
+  
+  // Check settings.json
+  const settingsPath = join(CLAUDE_PROJECT_DIR, 'settings.json');
+  if (!existsSync(settingsPath)) {
+    console.log(chalk.red('\n✗ .claude/settings.json not found'));
+    console.log(chalk.gray('  Fix: Run ') + chalk.cyan('claude-agents init'));
+    issues++;
+  } else {
+    console.log(chalk.green('\n✓ .claude/settings.json found'));
+    
+    // Check hook configurations
+    try {
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      if (!settings.hooks) {
+        console.log(chalk.yellow('⚠ No hooks configured in settings.json'));
+        warnings++;
+      } else {
+        const expectedHooks = ['Stop', 'SubagentStop', 'PostToolUse', 'Notification'];
+        for (const hookName of expectedHooks) {
+          if (!settings.hooks[hookName]) {
+            console.log(chalk.yellow(`⚠ ${hookName} hook not configured`));
+            warnings++;
+          }
+        }
+      }
+    } catch (error) {
+      console.log(chalk.red('✗ Failed to parse settings.json'));
+      issues++;
+    }
+  }
+  
+  // Check uv installation
+  console.log(chalk.bold('\nChecking dependencies:'));
+  try {
+    execSync('which uv', { stdio: 'ignore' });
+    console.log(chalk.green('✓ uv is installed'));
+  } catch {
+    console.log(chalk.red('✗ uv not found'));
+    console.log(chalk.gray('  Fix: Install uv from https://github.com/astral-sh/uv'));
+    issues++;
+  }
+  
+  // Check Python
+  try {
+    const pythonVersion = execSync('python3 --version', { encoding: 'utf-8' }).trim();
+    console.log(chalk.green(`✓ Python installed: ${pythonVersion}`));
+  } catch {
+    console.log(chalk.yellow('⚠ Python 3 not found (required for hooks)'));
+    warnings++;
+  }
+  
+  // Summary
+  console.log(chalk.bold('\n📊 Diagnostic Summary:'));
+  if (issues === 0 && warnings === 0) {
+    console.log(chalk.green('✅ All checks passed! Your installation is healthy.'));
+  } else {
+    if (issues > 0) {
+      console.log(chalk.red(`❌ ${issues} critical issue${issues > 1 ? 's' : ''} found`));
+    }
+    if (warnings > 0) {
+      console.log(chalk.yellow(`⚠️  ${warnings} warning${warnings > 1 ? 's' : ''} found`));
+    }
+    
+    console.log(chalk.bold('\n🔧 Quick fix for all issues:'));
+    console.log(chalk.cyan('  1. claude-agents init'));
+    console.log(chalk.cyan('  2. chmod +x .claude/hooks/*.py'));
+    console.log(chalk.cyan('  3. chmod +x .claude/hooks/utils/llm/*.py'));
+    console.log(chalk.cyan('  4. chmod +x .claude/hooks/utils/tts/*.py'));
+  }
+  
+  // Check if we're in debug mode
+  if (process.env.DEBUG) {
+    console.log(chalk.gray('\n🐛 Debug mode enabled'));
+    console.log(chalk.gray('Working directory: ' + process.cwd()));
+    console.log(chalk.gray('Claude directory: ' + CLAUDE_PROJECT_DIR));
+  }
+}

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import ora from 'ora';
-import { writeFileSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, appendFileSync } from 'fs';
+import { writeFileSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, appendFileSync, chmodSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import inquirer from 'inquirer';
@@ -15,6 +15,10 @@ import {
   getAgentDetails,
   formatAgentForInstall
 } from '../utils/agents.js';
+import { 
+  createHookFiles,
+  createSettingsTemplate
+} from '../utils/hooks.js';
 import { detectContextForge } from '../utils/contextForgeDetector.js';
 import { addInstalledAgent, saveConfig, DEFAULT_CONFIG } from '../utils/config.js';
 
@@ -196,6 +200,211 @@ export async function initCommand(options) {
       mkdirSync(memoryDir, { recursive: true });
     }
     
+    // Create hooks directory structure (default behavior, skip with --no-hooks)
+    if (options.hooks !== false) {
+      spinner.start('Setting up Claude Code hooks...');
+      const hooksDir = join(CLAUDE_PROJECT_DIR, 'hooks');
+      const hooksUtilsDir = join(hooksDir, 'utils');
+      const hooksLlmDir = join(hooksUtilsDir, 'llm');
+      const hooksTtsDir = join(hooksUtilsDir, 'tts');
+      
+      // Check if hooks already exist
+      const hooksExisted = existsSync(hooksDir);
+      if (hooksExisted) {
+        console.log(chalk.gray('\n  • Found existing hooks directory, updating...'));
+      }
+      
+      // Ensure hooks directories exist
+      [hooksDir, hooksUtilsDir, hooksLlmDir, hooksTtsDir].forEach(dir => {
+        if (!existsSync(dir)) {
+          mkdirSync(dir, { recursive: true });
+        }
+      });
+      
+      // Copy hook files from templates
+      const templatesHooksDir = join(__dirname, '..', '..', 'templates', 'hooks');
+      if (existsSync(templatesHooksDir)) {
+        // Copy hook scripts
+        const hookFiles = ['subagent_stop.py', 'stop.py', 'post_tool_use.py', 'post_tool_use_elevenlabs.py', 'notification.py'];
+        for (const file of hookFiles) {
+          const srcPath = join(templatesHooksDir, file);
+          const destPath = join(hooksDir, file);
+          if (existsSync(srcPath)) {
+            copyFileSync(srcPath, destPath);
+            // Make the hook executable
+            chmodSync(destPath, '755');
+            console.log(chalk.gray(`  • Copied hook: ${file}`));
+          } else {
+            console.log(chalk.yellow(`  • Warning: Hook template not found: ${file}`));
+          }
+        }
+        
+        // Copy utils directories
+        const utilsTemplateDir = join(templatesHooksDir, 'utils');
+        if (existsSync(utilsTemplateDir)) {
+          // Copy LLM utilities
+          const llmTemplateDir = join(utilsTemplateDir, 'llm');
+          if (existsSync(llmTemplateDir)) {
+            const llmFiles = readdirSync(llmTemplateDir).filter(f => f.endsWith('.py'));
+            for (const file of llmFiles) {
+              const destPath = join(hooksLlmDir, file);
+              copyFileSync(join(llmTemplateDir, file), destPath);
+              chmodSync(destPath, '755');
+            }
+          }
+          
+          // Copy TTS utilities
+          const ttsTemplateDir = join(utilsTemplateDir, 'tts');
+          if (existsSync(ttsTemplateDir)) {
+            const ttsFiles = readdirSync(ttsTemplateDir).filter(f => f.endsWith('.py'));
+            for (const file of ttsFiles) {
+              const destPath = join(hooksTtsDir, file);
+              copyFileSync(join(ttsTemplateDir, file), destPath);
+              chmodSync(destPath, '755');
+            }
+          }
+        }
+      } else {
+        // Fallback to inline hook creation if templates don't exist
+        const hookFiles = await createHookFiles(hooksDir, hooksLlmDir, hooksTtsDir);
+      }
+      
+      // Create or merge settings.json template for hooks
+      const settingsPath = join(CLAUDE_PROJECT_DIR, 'settings.json');
+      const projectPath = process.cwd();
+      
+      if (!existsSync(settingsPath)) {
+        // No existing settings.json - create with absolute paths
+        const settingsContent = {
+          "permissions": {
+            "allow": [
+              "Bash(mkdir:*)",
+              "Bash(uv:*)",
+              "Bash(find:*)",
+              "Bash(mv:*)",
+              "Bash(grep:*)",
+              "Bash(npm:*)",
+              "Bash(ls:*)",
+              "Bash(cp:*)",
+              "Write",
+              "Edit",
+              "Bash(chmod:*)",
+              "Bash(touch:*)"
+            ],
+            "deny": []
+          },
+          "hooks": {
+            "Stop": [{
+              "matcher": "",
+              "hooks": [{
+                "type": "command",
+                "command": `python3 ${projectPath}/.claude/hooks/stop.py --chat`
+              }]
+            }],
+            "SubagentStop": [{
+              "matcher": "",
+              "hooks": [{
+                "type": "command",
+                "command": `python3 ${projectPath}/.claude/hooks/subagent_stop.py`
+              }]
+            }],
+            "PostToolUse": [{
+              "matcher": "",
+              "hooks": [{
+                "type": "command",
+                "command": `python3 ${projectPath}/.claude/hooks/post_tool_use_elevenlabs.py`
+              }]
+            }],
+            "Notification": [{
+              "matcher": "",
+              "hooks": [{
+                "type": "command",
+                "command": `python3 ${projectPath}/.claude/hooks/notification.py`
+              }]
+            }]
+          }
+        };
+        writeFileSync(settingsPath, JSON.stringify(settingsContent, null, 2));
+      } else {
+        // Existing settings.json - merge with template
+        try {
+          const existingSettings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+          
+          // Define hooks with absolute paths
+          const newHooks = {
+            "Stop": [{
+              "matcher": "",
+              "hooks": [{
+                "type": "command",
+                "command": `python3 ${projectPath}/.claude/hooks/stop.py --chat`
+              }]
+            }],
+            "SubagentStop": [{
+              "matcher": "",
+              "hooks": [{
+                "type": "command",
+                "command": `python3 ${projectPath}/.claude/hooks/subagent_stop.py`
+              }]
+            }],
+            "PostToolUse": [{
+              "matcher": "",
+              "hooks": [{
+                "type": "command",
+                "command": `python3 ${projectPath}/.claude/hooks/post_tool_use_elevenlabs.py`
+              }]
+            }],
+            "Notification": [{
+              "matcher": "",
+              "hooks": [{
+                "type": "command",
+                "command": `python3 ${projectPath}/.claude/hooks/notification.py`
+              }]
+            }]
+          };
+          
+          // Merge hooks, preserving existing ones
+          if (!existingSettings.hooks) {
+            existingSettings.hooks = {};
+          }
+          
+          // Add new hooks from template without overwriting existing ones
+          for (const [hookName, hookConfig] of Object.entries(newHooks)) {
+            if (!existingSettings.hooks[hookName]) {
+              existingSettings.hooks[hookName] = hookConfig;
+            }
+          }
+          
+          // Merge permissions
+          if (!existingSettings.permissions) {
+            existingSettings.permissions = {
+              "allow": [
+                "Bash(mkdir:*)",
+                "Bash(uv:*)",
+                "Bash(find:*)",
+                "Bash(mv:*)",
+                "Bash(grep:*)",
+                "Bash(npm:*)",
+                "Bash(ls:*)",
+                "Bash(cp:*)",
+                "Write",
+                "Edit",
+                "Bash(chmod:*)",
+                "Bash(touch:*)"
+              ],
+              "deny": []
+            };
+          }
+          
+          writeFileSync(settingsPath, JSON.stringify(existingSettings, null, 2));
+          console.log(chalk.gray('  • Merged hooks configuration into existing settings.json'));
+        } catch (error) {
+          console.error(chalk.yellow('  • Warning: Could not merge settings.json, keeping existing file'));
+        }
+      }
+      
+      spinner.succeed('Claude Code hooks created');
+    }
+    
     // Final message
     console.log('');
     console.log(chalk.green('✨ Initialization complete!'));
@@ -209,6 +418,25 @@ export async function initCommand(options) {
       console.log(chalk.gray('4. Check .claude/commands/agents/ for agent-specific commands'));
     } else {
       console.log(chalk.gray('3. Use slash commands in Claude Code (e.g., /review)'));
+    }
+    
+    console.log('');
+    console.log(chalk.bold.cyan('🔊 NEW: Voice Features & Hooks'));
+    console.log(chalk.gray('Configure voice announcements:'), chalk.cyan('claude-agents voice'));
+    console.log(chalk.gray('Run agents with voice:'), chalk.cyan('claude-agents run <agent> --task "..." --voice'));
+    
+    if (options.hooks !== false) {
+      console.log('');
+      console.log(chalk.bold.cyan('🪝 Claude Code Hooks Installed'));
+      console.log(chalk.gray('• Stop hook:'), chalk.cyan('.claude/hooks/stop.py'), chalk.gray('- LLM-generated completion messages'));
+      console.log(chalk.gray('• SubagentStop hook:'), chalk.cyan('.claude/hooks/subagent_stop.py'), chalk.gray('- Agent completion notifications'));
+      console.log(chalk.gray('• Voice hook:'), chalk.cyan('.claude/hooks/post_tool_use_elevenlabs.py'), chalk.gray('- AI summaries + ElevenLabs TTS'));
+      console.log(chalk.gray('• TTS providers:'), chalk.cyan('ElevenLabs (Sarah voice) > Local'));
+      console.log(chalk.gray('• Engineer name support:'), chalk.cyan('ENGINEER_NAME=YourName'), chalk.gray('env variable'));
+      console.log(chalk.gray('• Configure:'), chalk.cyan('.claude/settings.json'), chalk.gray('- Hook permissions & settings'));
+    } else {
+      console.log('');
+      console.log(chalk.gray('🪝 Claude Code hooks skipped (use --no-hooks flag)'));
     }
     
   } catch (error) {
@@ -298,6 +526,7 @@ The following agents are installed in \`.claude/agents/\`:
 - **api-documenter**: OpenAPI/Swagger documentation specialist
 - **test-runner**: Automated test execution specialist
 - **shadcn-ui-builder**: UI/UX implementation with ShadCN components
+- **meta-agent**: Agent generator that creates new sub-agents from descriptions
 
 ### Using Sub-Agents
 
@@ -306,6 +535,7 @@ Agents work alongside your existing PRPs and can be invoked in several ways:
 1. **Direct execution**: \`claude-agents run <agent> --task "description"\`
 2. **Task tool in Claude Code**: \`Task("agent-name: task description")\`
 3. **Agent slash commands**: Located in \`.claude/commands/agents/\`
+4. **With voice announcements**: \`claude-agents run <agent> --task "..." --voice\`
 
 ### Memory System
 
@@ -319,5 +549,16 @@ Agents share context and coordinate through:
 - Use agents for specialized tasks that match their expertise
 - Agents can read and understand your PRPs for context
 - Multiple agents can work on different aspects of the same feature
-- Memory system allows agents to build on each other's work`;
+- Memory system allows agents to build on each other's work
+
+### Voice Features (NEW in v1.5.0)
+
+Enable voice announcements for agent completions:
+
+1. **Configure voice**: \`claude-agents voice\`
+2. **Set up MCP for ElevenLabs** (recommended):
+   \`\`\`bash
+   claude mcp add ElevenLabs -e ELEVENLABS_API_KEY=your-key -- uvx elevenlabs-mcp
+   \`\`\`
+3. **Or use OpenAI/Local TTS**: Configure API keys with \`claude-agents voice --api-key\``;
 }

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import ora from 'ora';
-import { writeFileSync, copyFileSync, existsSync, mkdirSync } from 'fs';
+import { writeFileSync, copyFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { 
@@ -28,6 +28,28 @@ import { detectContextForge } from '../utils/contextForgeDetector.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+/**
+ * Force a command file's frontmatter `name` to a given value.
+ *
+ * Context-forge installs rename command files to `agent-<command>.md` to avoid
+ * conflicts, but the slash-command resolver prefers an explicit frontmatter
+ * `name:` over the filename. Without rewriting it, a `name: api` field would
+ * make the prefixed `agent-api.md` register as `api`, silently defeating the
+ * rename. Rewriting the name to match the prefixed filename keeps both the
+ * explicit-name discoverability and the conflict-avoidance prefix.
+ */
+export function setCommandName(content, name) {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) {
+    return `---\nname: ${name}\n---\n\n${content}`;
+  }
+  const fm = fmMatch[1];
+  const newFm = /^name:.*$/m.test(fm)
+    ? fm.replace(/^name:.*$/m, `name: ${name}`)
+    : `name: ${name}\n${fm}`;
+  return content.replace(fmMatch[0], `---\n${newFm}\n---`);
+}
 
 export async function installCommand(options) {
   const spinner = ora();
@@ -131,12 +153,19 @@ export async function installCommand(options) {
           for (const command of agentDetails.commands) {
             const srcPath = join(__dirname, '..', '..', 'commands', `${command}.md`);
             if (existsSync(srcPath)) {
+              const isPrefixed = contextForgeInfo.hasContextForge && isProject;
               // Prefix command name if in context-forge project to avoid conflicts
-              const commandName = contextForgeInfo.hasContextForge && isProject
-                ? `agent-${command}.md`
-                : `${command}.md`;
+              const commandName = isPrefixed ? `agent-${command}.md` : `${command}.md`;
               const destPath = join(targetCommandsDir, commandName);
-              copyFileSync(srcPath, destPath);
+
+              if (isPrefixed) {
+                // Rewrite the frontmatter `name` to match the prefixed filename so an
+                // explicit `name:` field can't defeat the conflict-avoidance rename.
+                const content = readFileSync(srcPath, 'utf-8');
+                writeFileSync(destPath, setCommandName(content, `agent-${command}`));
+              } else {
+                copyFileSync(srcPath, destPath);
+              }
             }
           }
         }

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -4,20 +4,33 @@ import { join } from 'path';
 import inquirer from 'inquirer';
 import ora from 'ora';
 import { getAgentsDir, CLAUDE_PROJECT_AGENTS_DIR, CLAUDE_USER_AGENTS_DIR } from '../utils/paths.js';
-import { loadConfig } from '../utils/config.js';
+import { loadConfig, getVoiceConfig } from '../utils/config.js';
 import { getMemoryStore } from '../memory/index.js';
+import { createHandoff, getAvailableHandoffs, formatHandoffInputs, createSummary } from '../utils/handoff.js';
+import { createTaskExecution, completeTaskExecution, failTaskExecution } from '../utils/hooks/task-integration.js';
+import { isClaudeCodeEnvironment } from '../utils/hooks/runner.js';
 import yaml from 'yaml';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import { announceAgentComplete, announceError } from '../utils/tts/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 export async function runCommand(agentName, options) {
   const spinner = ora();
+  const voiceConfig = getVoiceConfig();
+  const useVoice = options.voice !== undefined ? options.voice : voiceConfig.enabled;
+  const isClaudeCode = isClaudeCodeEnvironment();
+  let taskData = null;
   
   try {
     console.log(chalk.bold.blue(`🤖 Running ${agentName} Agent\n`));
+    
+    // Show environment context
+    if (isClaudeCode) {
+      console.log(chalk.gray('🔗 Running in Claude Code environment - hooks enabled'));
+    }
     
     // Find the agent file
     const config = loadConfig();
@@ -143,6 +156,15 @@ export async function runCommand(agentName, options) {
       status: 'running'
     }, 3600000); // 1 hour TTL
     
+    // Create task tracking for hooks integration
+    if (isClaudeCode) {
+      taskData = createTaskExecution(agentName, task, {
+        targetFile,
+        executionId,
+        verbose: options.verbose || process.env.DEBUG === 'claude-agents'
+      });
+    }
+    
     // Share task context with other agents
     memory.set(`shared:current-task`, {
       agent: agentName,
@@ -150,12 +172,41 @@ export async function runCommand(agentName, options) {
       executionId
     }, 3600000);
     
+    // Check for available handoffs
+    const availableHandoffs = getAvailableHandoffs(agentName);
+    const handoffInputs = formatHandoffInputs(availableHandoffs);
+    
+    if (availableHandoffs.length > 0) {
+      console.log(chalk.bold.blue('\n📥 Available Handoffs:'));
+      availableHandoffs.forEach(handoff => {
+        console.log(chalk.gray('├─'), `From ${handoff.from}:`, chalk.yellow(handoff.type));
+        console.log(chalk.gray('│  '), chalk.dim(handoff.summary));
+      });
+      console.log();
+    }
+    
     spinner.start('Initializing agent...');
     
-    // Simulate agent execution
+    // Load metadata to check consumes/produces
+    const metadataPath = join(dirname(agentPath), 'metadata.json');
+    let metadata = {};
+    if (existsSync(metadataPath)) {
+      metadata = JSON.parse(readFileSync(metadataPath, 'utf-8'));
+    }
+    
+    // Check if agent has required inputs
+    const requiredInputs = metadata.consumes || [];
+    const availableTypes = Object.keys(handoffInputs);
+    const missingInputs = requiredInputs.filter(req => !availableTypes.includes(req));
+    
+    if (missingInputs.length > 0 && requiredInputs.length > 0) {
+      spinner.warn('Missing required inputs: ' + missingInputs.join(', '));
+    }
+    
+    // Simulate agent execution with handoff context
     // In a real implementation, this would:
     // 1. Create an isolated execution context
-    // 2. Load the agent with its specific tools
+    // 2. Pass handoff inputs to the agent
     // 3. Execute the task
     // 4. Return results
     
@@ -168,14 +219,56 @@ export async function runCommand(agentName, options) {
     await new Promise(resolve => setTimeout(resolve, 1500));
     spinner.succeed('Agent execution completed');
     
+    // Voice announcement for completion
+    if (useVoice) {
+      await announceAgentComplete(agentName, task);
+    }
+    
     // Update execution status
-    memory.set(`agent:${agentName}:last-execution`, {
+    const completionData = {
       id: executionId,
       task,
       targetFile,
       completedAt: new Date().toISOString(),
       status: 'completed'
-    });
+    };
+    memory.set(`agent:${agentName}:last-execution`, completionData);
+    
+    // Create handoffs for agent outputs
+    const produces = metadata.produces || [];
+    if (produces.length > 0) {
+      // Simulate agent outputs (in real implementation, these would come from agent)
+      const mockOutputs = {
+        'technical-plan': { phases: ['design', 'implement', 'test'], duration: '5 days' },
+        'api-implementation': { endpoints: ['/users', '/products'], status: 'complete' },
+        'test-results': { passed: 10, failed: 0, coverage: '95%' },
+        'review-report': { issues: 2, suggestions: 5, approved: true }
+      };
+      
+      produces.forEach(outputType => {
+        if (mockOutputs[outputType]) {
+          const summary = createSummary(agentName, task, { success: true, output_type: outputType });
+          createHandoff(agentName, '*', outputType, mockOutputs[outputType], summary);
+          console.log(chalk.gray('├─'), 'Created handoff:', chalk.cyan(outputType));
+        }
+      });
+    }
+    
+    // Complete task tracking and emit hooks
+    if (isClaudeCode && taskData) {
+      try {
+        await completeTaskExecution(taskData.id, {
+          success: true,
+          handoffs: produces.map(type => ({ type, data: mockOutputs[type] })),
+          outputs: mockOutputs,
+          completionData
+        }, {
+          verbose: options.verbose || process.env.DEBUG === 'claude-agents'
+        });
+      } catch (hookError) {
+        console.warn(chalk.yellow('Warning: Hook execution failed:'), hookError.message);
+      }
+    }
     
     // Display results
     console.log('\n' + chalk.bold.green('✨ Execution Summary:'));
@@ -223,6 +316,23 @@ export async function runCommand(agentName, options) {
   } catch (error) {
     spinner.fail('Agent execution failed');
     console.error(chalk.red('Error:'), error.message);
+    
+    // Complete task tracking with failure
+    if (isClaudeCode && taskData) {
+      try {
+        await failTaskExecution(taskData.id, error, {
+          verbose: options.verbose || process.env.DEBUG === 'claude-agents'
+        });
+      } catch (hookError) {
+        console.warn(chalk.yellow('Warning: Hook execution failed:'), hookError.message);
+      }
+    }
+    
+    // Voice announcement for error
+    if (useVoice) {
+      await announceError(error.message, agentName);
+    }
+    
     process.exit(1);
   }
 }

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -1,0 +1,287 @@
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import ora from 'ora';
+import { existsSync } from 'fs';
+import { getAvailableAgents } from '../utils/agents.js';
+import { loadEnv, saveEnv, backupEnv } from '../utils/env.js';
+import { loadConfig, saveConfig } from '../utils/config.js';
+import { execSync } from 'child_process';
+import { join } from 'path';
+
+// Agent categories for better organization
+const AGENT_CATEGORIES = {
+  'Development': ['api-developer', 'frontend-developer', 'refactor'],
+  'Testing': ['tdd-specialist', 'test-runner', 'debugger'],
+  'Documentation': ['doc-writer', 'api-documenter'],
+  'Review & Security': ['code-reviewer', 'security-scanner'],
+  'DevOps': ['devops-engineer'],
+  'Product': ['product-manager', 'project-planner'],
+  'UI/UX': ['shadcn-ui-builder'],
+  'Meta': ['meta-agent'],
+  'Marketing': ['marketing-writer']
+};
+
+export async function setupCommand(options) {
+  console.log(chalk.bold.blue('🧙 Claude Sub-Agents Setup Wizard\n'));
+  
+  // Determine setup mode
+  let setupMode = 'full';
+  if (options.agentsOnly) setupMode = 'agents';
+  else if (options.voiceOnly) setupMode = 'voice';
+  else if (options.keysOnly) setupMode = 'keys';
+  
+  try {
+    // Load current configuration
+    const currentEnv = loadEnv();
+    const config = loadConfig();
+    
+    // Create backup of .env file
+    backupEnv();
+    
+    let setupData = {
+      agents: Object.keys(config.installedAgents || {}),
+      voiceProvider: currentEnv.VOICE_PROVIDER || 'local',
+      llmProvider: currentEnv.LLM_PROVIDER || 'openai',
+      apiKeys: {}
+    };
+    
+    // Run appropriate setup steps based on mode
+    if (setupMode === 'full' || setupMode === 'agents') {
+      setupData = await setupAgents(setupData);
+    }
+    
+    if (setupMode === 'full' || setupMode === 'voice') {
+      setupData = await setupVoice(setupData);
+    }
+    
+    if (setupMode === 'full' || setupMode === 'keys') {
+      setupData = await setupApiKeys(setupData);
+    }
+    
+    // Show summary
+    console.log('\n' + chalk.bold.cyan('📋 Setup Summary:'));
+    console.log(chalk.gray('─'.repeat(50)));
+    
+    if (setupData.agents) {
+      console.log(chalk.yellow('Agents:'), setupData.agents.length ? 
+        setupData.agents.join(', ') : 'None selected');
+    }
+    
+    console.log(chalk.yellow('Voice Provider:'), setupData.voiceProvider);
+    console.log(chalk.yellow('LLM Provider:'), setupData.llmProvider);
+    
+    const configuredKeys = Object.keys(setupData.apiKeys).filter(k => setupData.apiKeys[k]);
+    console.log(chalk.yellow('API Keys:'), configuredKeys.length ? 
+      configuredKeys.join(', ') : 'None configured');
+    
+    // Confirm and apply
+    const { confirmSetup } = await inquirer.prompt([{
+      type: 'confirm',
+      name: 'confirmSetup',
+      message: 'Apply this configuration?',
+      default: true
+    }]);
+    
+    if (!confirmSetup) {
+      console.log(chalk.yellow('\n✖ Setup cancelled'));
+      return;
+    }
+    
+    // Apply configuration
+    const spinner = ora('Applying configuration...').start();
+    
+    // Update environment variables
+    const envUpdates = {
+      VOICE_PROVIDER: setupData.voiceProvider,
+      VOICE_ENABLED: setupData.voiceProvider !== 'none' ? 'true' : 'false',
+      LLM_PROVIDER: setupData.llmProvider,
+      ...setupData.apiKeys
+    };
+    
+    saveEnv(envUpdates);
+    
+    // Update config for agents
+    if (setupData.agents) {
+      // This would normally update the actual agent installation
+      // For now, just update the config
+      config.installedAgents = setupData.agents;
+      saveConfig(config);
+    }
+    
+    spinner.succeed('Configuration applied successfully!');
+    
+    // Test voice if configured
+    if (setupData.voiceProvider !== 'none' && setupData.voiceProvider !== 'mcp') {
+      const { testVoice } = await inquirer.prompt([{
+        type: 'confirm',
+        name: 'testVoice',
+        message: 'Would you like to test voice announcements?',
+        default: true
+      }]);
+      
+      if (testVoice) {
+        console.log(chalk.gray('\n🔊 Testing voice...'));
+        try {
+          execSync(`node ${join(process.cwd(), 'src/index.js')} voice --test "Setup complete!"`, 
+            { stdio: 'inherit' });
+        } catch (error) {
+          console.error(chalk.red('Voice test failed:'), error.message);
+        }
+      }
+    }
+    
+    // Show next steps
+    console.log('\n' + chalk.bold.green('✨ Setup Complete!'));
+    console.log('\n' + chalk.bold('Next steps:'));
+    console.log(chalk.gray('1.'), 'Run an agent:', chalk.cyan('claude-agents run <agent> --task "..."'));
+    console.log(chalk.gray('2.'), 'View status:', chalk.cyan('claude-agents status'));
+    console.log(chalk.gray('3.'), 'Launch dashboard:', chalk.cyan('claude-agents dashboard'));
+    
+    if (setupData.voiceProvider === 'mcp') {
+      console.log('\n' + chalk.yellow('⚠️  MCP ElevenLabs requires:'));
+      console.log(chalk.gray('1. Install MCP server:'), chalk.cyan('claude mcp add ElevenLabs'));
+      console.log(chalk.gray('2. Add API key:'), chalk.cyan('-e ELEVENLABS_API_KEY=your-key'));
+      console.log(chalk.gray('3. Complete command:'), chalk.cyan('-- uvx elevenlabs-mcp'));
+    }
+    
+  } catch (error) {
+    console.error(chalk.red('\n✖ Setup failed:'), error.message);
+    console.log(chalk.yellow('Your .env file has been backed up to .env.backup'));
+    process.exit(1);
+  }
+}
+
+async function setupAgents(setupData) {
+  console.log(chalk.bold.cyan('\n🤖 Agent Selection'));
+  console.log(chalk.gray('Select which agents to install/enable:\n'));
+  
+  const availableAgents = getAvailableAgents();
+  const config = loadConfig();
+  const installedAgentNames = Object.keys(config.installedAgents || {});
+  
+  // Create choices organized by category
+  const choices = [];
+  
+  for (const [category, agentNames] of Object.entries(AGENT_CATEGORIES)) {
+    choices.push(new inquirer.Separator(chalk.bold.yellow(`\n${category}`)));
+    
+    for (const agentName of agentNames) {
+      const agent = availableAgents.find(a => a.name === agentName);
+      if (agent) {
+        const isInstalled = installedAgentNames.includes(agentName);
+        choices.push({
+          name: `${agent.name} - ${agent.description} ${isInstalled ? chalk.green('(installed)') : ''}`,
+          value: agent.name,
+          checked: isInstalled
+        });
+      }
+    }
+  }
+  
+  const { selectedAgents } = await inquirer.prompt([{
+    type: 'checkbox',
+    name: 'selectedAgents',
+    message: 'Select agents:',
+    choices,
+    pageSize: 20
+  }]);
+  
+  setupData.agents = selectedAgents;
+  return setupData;
+}
+
+async function setupVoice(setupData) {
+  console.log(chalk.bold.cyan('\n🔊 Voice Configuration'));
+  
+  const { voiceProvider } = await inquirer.prompt([{
+    type: 'list',
+    name: 'voiceProvider',
+    message: 'Select voice provider:',
+    choices: [
+      {
+        name: 'Local TTS (Fast, Offline) - macOS/Linux system voices',
+        value: 'local'
+      },
+      {
+        name: 'OpenAI TTS (High Quality) - Requires API key',
+        value: 'openai'
+      },
+      {
+        name: 'MCP ElevenLabs (Premium) - For Claude Code only',
+        value: 'mcp'
+      },
+      {
+        name: 'None - Disable voice announcements',
+        value: 'none'
+      }
+    ],
+    default: setupData.voiceProvider
+  }]);
+  
+  setupData.voiceProvider = voiceProvider;
+  
+  // Configure provider-specific settings
+  if (voiceProvider === 'openai') {
+    setupData.requiresOpenAI = true;
+  } else if (voiceProvider === 'mcp') {
+    console.log(chalk.yellow('\n⚠️  MCP ElevenLabs requires additional setup in Claude Code'));
+  }
+  
+  return setupData;
+}
+
+async function setupApiKeys(setupData) {
+  console.log(chalk.bold.cyan('\n🔑 API Key Configuration'));
+  console.log(chalk.gray('Enter API keys for selected services (leave blank to skip):\n'));
+  
+  const keysToConfig = [];
+  
+  // Determine which keys we need based on selections
+  if (setupData.llmProvider === 'openai' || setupData.requiresOpenAI) {
+    keysToConfig.push({ name: 'OpenAI', key: 'OPENAI_API_KEY' });
+  }
+  
+  if (setupData.llmProvider === 'anthropic') {
+    keysToConfig.push({ name: 'Anthropic', key: 'ANTHROPIC_API_KEY' });
+  }
+  
+  if (setupData.voiceProvider === 'mcp' || setupData.voiceProvider === 'elevenlabs') {
+    keysToConfig.push({ name: 'ElevenLabs', key: 'ELEVENLABS_API_KEY' });
+  }
+  
+  // Always offer to configure engineer name
+  keysToConfig.push({ name: 'Engineer Name (for personalized messages)', key: 'ENGINEER_NAME', isName: true });
+  
+  const currentEnv = loadEnv();
+  
+  for (const keyConfig of keysToConfig) {
+    const currentValue = currentEnv[keyConfig.key];
+    const hasValue = currentValue && currentValue !== '';
+    
+    const prompt = {
+      type: keyConfig.isName ? 'input' : 'password',
+      name: 'value',
+      message: `${keyConfig.name}:`,
+      default: hasValue ? (keyConfig.isName ? currentValue : '(configured)') : undefined,
+      when: () => {
+        if (hasValue && !keyConfig.isName) {
+          return inquirer.prompt([{
+            type: 'confirm',
+            name: 'update',
+            message: `${keyConfig.name} is already configured. Update it?`,
+            default: false
+          }]).then(a => a.update);
+        }
+        return true;
+      }
+    };
+    
+    const { value } = await inquirer.prompt([prompt]);
+    
+    if (value && value !== '(configured)') {
+      setupData.apiKeys[keyConfig.key] = value;
+    }
+  }
+  
+  return setupData;
+}

--- a/src/commands/voice.js
+++ b/src/commands/voice.js
@@ -1,0 +1,570 @@
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import ora from 'ora';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { getVoiceConfig, saveVoiceConfig, getAPIKeys, saveAPIKey } from '../utils/config.js';
+import { hasApiKey, getEnvVar, saveEnv, loadEnv } from '../utils/env.js';
+import { getTTS } from '../utils/tts/index.js';
+
+const execAsync = promisify(exec);
+
+export async function voiceCommand(options) {
+  const spinner = ora();
+  
+  try {
+    // Handle new options
+    if (options.setup) {
+      await handleSetup();
+      return;
+    }
+    
+    if (options.status) {
+      await handleStatus();
+      return;
+    }
+    
+    // If specific action provided
+    if (options.enable !== undefined) {
+      await handleEnable(options.enable);
+      return;
+    }
+    
+    if (options.provider) {
+      await handleProvider(options.provider);
+      return;
+    }
+    
+    if (options.test) {
+      await handleTest(options.test);
+      return;
+    }
+    
+    if (options.apiKey) {
+      await handleAPIKey(options.apiKey);
+      return;
+    }
+    
+    // Interactive menu
+    await showInteractiveMenu();
+    
+  } catch (error) {
+    spinner.fail('Voice command failed');
+    console.error(chalk.red('Error:'), error.message);
+    process.exit(1);
+  }
+}
+
+async function handleSetup() {
+  console.log(chalk.bold.blue('\n🎙️  Claude Agents Voice Setup Wizard\n'));
+  
+  // Step 1: Check ffmpeg installation
+  await checkFFmpegInstallation();
+  
+  // Step 2: Select voice provider
+  const provider = await selectVoiceProvider();
+  
+  // Step 3: Configure API keys based on provider selection
+  await configureProviderKeys(provider);
+  
+  // Step 4: Provide MCP setup instructions if needed
+  if (provider === 'mcp' || provider === 'elevenlabs') {
+    await showMCPSetupInstructions();
+  }
+  
+  // Step 5: Save configuration
+  await saveSetupConfiguration(provider);
+  
+  // Step 6: Test voice setup
+  await testVoiceSetup();
+  
+  console.log(chalk.green.bold('\n🎉 Voice setup completed successfully!'));
+  console.log(chalk.gray('You can now use voice features with claude-agents.'));
+}
+
+async function handleStatus() {
+  console.log(chalk.bold.blue('\n🔊 Voice System Status\n'));
+  
+  // Check ffmpeg
+  const ffmpegStatus = await checkFFmpegAvailable();
+  console.log(chalk.bold('System Dependencies:'));
+  console.log(chalk.gray('├─'), 'FFmpeg:', ffmpegStatus ? chalk.green('Installed') : chalk.red('Not installed'));
+  
+  // Check configuration
+  const config = getVoiceConfig();
+  const env = loadEnv();
+  
+  console.log(chalk.bold('\nConfiguration:'));
+  console.log(chalk.gray('├─'), 'Status:', config.enabled ? chalk.green('Enabled') : chalk.red('Disabled'));
+  console.log(chalk.gray('├─'), 'Provider:', chalk.cyan(config.provider));
+  
+  // Check API keys
+  console.log(chalk.bold('\nAPI Keys:'));
+  console.log(chalk.gray('├─'), 'OpenAI:', hasApiKey('OPENAI_API_KEY') ? chalk.green('Configured') : chalk.gray('Not set'));
+  console.log(chalk.gray('├─'), 'ElevenLabs:', hasApiKey('ELEVENLABS_API_KEY') ? chalk.green('Configured') : chalk.gray('Not set'));
+  console.log(chalk.gray('└─'), 'Anthropic:', hasApiKey('ANTHROPIC_API_KEY') ? chalk.green('Configured') : chalk.gray('Not set'));
+  
+  // Check MCP setup for ElevenLabs
+  if (config.provider === 'mcp') {
+    console.log(chalk.bold('\nMCP Integration:'));
+    console.log(chalk.gray('└─'), 'ElevenLabs MCP:', chalk.yellow('Check Claude Code MCP tools'));
+  }
+  
+  // Show recommendations
+  const recommendations = getSetupRecommendations();
+  if (recommendations.length > 0) {
+    console.log(chalk.bold('\nRecommendations:'));
+    recommendations.forEach((rec, index) => {
+      const isLast = index === recommendations.length - 1;
+      console.log(chalk.gray(isLast ? '└─' : '├─'), chalk.yellow(rec));
+    });
+  }
+}
+
+async function checkFFmpegInstallation() {
+  const spinner = ora('Checking FFmpeg installation...').start();
+  
+  const isInstalled = await checkFFmpegAvailable();
+  
+  if (isInstalled) {
+    spinner.succeed('FFmpeg is already installed');
+  } else {
+    spinner.warn('FFmpeg is not installed');
+    
+    console.log(chalk.yellow('\n⚠️  FFmpeg is required for voice functionality'));
+    console.log(chalk.bold('\nInstallation Instructions:'));
+    
+    const platform = process.platform;
+    switch (platform) {
+      case 'darwin':
+        console.log(chalk.white('  macOS:'), chalk.cyan('brew install ffmpeg'));
+        break;
+      case 'win32':
+        console.log(chalk.white('  Windows:'), chalk.cyan('choco install ffmpeg'));
+        console.log(chalk.gray('    or download from: https://ffmpeg.org/download.html'));
+        break;
+      case 'linux':
+        console.log(chalk.white('  Ubuntu/Debian:'), chalk.cyan('sudo apt-get install ffmpeg'));
+        console.log(chalk.white('  CentOS/RHEL:'), chalk.cyan('sudo yum install ffmpeg'));
+        console.log(chalk.white('  Arch:'), chalk.cyan('sudo pacman -S ffmpeg'));
+        break;
+      default:
+        console.log(chalk.white('  Your platform:'), chalk.cyan('Visit https://ffmpeg.org/download.html'));
+    }
+    
+    const proceed = await inquirer.prompt({
+      type: 'confirm',
+      name: 'continue',
+      message: 'Continue setup without FFmpeg? (You can install it later)',
+      default: true
+    });
+    
+    if (!proceed.continue) {
+      console.log(chalk.yellow('Setup cancelled. Install FFmpeg and run setup again.'));
+      process.exit(0);
+    }
+  }
+}
+
+async function selectVoiceProvider() {
+  const answers = await inquirer.prompt({
+    type: 'list',
+    name: 'provider',
+    message: 'Select your preferred voice provider:',
+    choices: [
+      {
+        name: 'Auto (best available) - Recommended',
+        value: 'auto',
+        short: 'Auto'
+      },
+      {
+        name: 'ElevenLabs (via Claude Code MCP) - High quality',
+        value: 'mcp',
+        short: 'ElevenLabs MCP'
+      },
+      {
+        name: 'OpenAI - Good quality, reliable',
+        value: 'openai',
+        short: 'OpenAI'
+      },
+      {
+        name: 'Local (system TTS) - No API key needed',
+        value: 'local',
+        short: 'Local'
+      }
+    ],
+    default: 'auto'
+  });
+  
+  return answers.provider;
+}
+
+async function configureProviderKeys(provider) {
+  const requiredKeys = getRequiredKeysForProvider(provider);
+  
+  if (requiredKeys.length === 0) {
+    console.log(chalk.green('✓ No API keys required for selected provider'));
+    return;
+  }
+  
+  console.log(chalk.bold('\n🔑 API Key Configuration'));
+  
+  const env = loadEnv();
+  const updates = {};
+  
+  for (const keyInfo of requiredKeys) {
+    const { key, name, required } = keyInfo;
+    const currentValue = env[key] || process.env[key];
+    
+    if (currentValue && !required) {
+      const useExisting = await inquirer.prompt({
+        type: 'confirm',
+        name: 'use',
+        message: `${name} API key is already configured. Keep existing?`,
+        default: true
+      });
+      
+      if (useExisting.use) {
+        continue;
+      }
+    }
+    
+    const answer = await inquirer.prompt({
+      type: 'password',
+      name: 'apiKey',
+      message: `Enter your ${name} API key:`,
+      mask: '*',
+      validate: input => {
+        if (!input.trim()) {
+          return required ? 'API key is required for this provider' : true;
+        }
+        return true;
+      }
+    });
+    
+    if (answer.apiKey) {
+      updates[key] = answer.apiKey;
+    }
+  }
+  
+  if (Object.keys(updates).length > 0) {
+    saveEnv(updates);
+    console.log(chalk.green('✓ API keys saved to .env file'));
+  }
+}
+
+async function showMCPSetupInstructions() {
+  console.log(chalk.bold('\n📡 ElevenLabs MCP Setup'));
+  console.log(chalk.gray('To use ElevenLabs through Claude Code MCP integration:\n'));
+  
+  const apiKey = getEnvVar('ELEVENLABS_API_KEY');
+  const mcpCommand = apiKey 
+    ? `claude mcp add ElevenLabs -e ELEVENLABS_API_KEY=${apiKey} -- uvx elevenlabs-mcp`
+    : 'claude mcp add ElevenLabs -e ELEVENLABS_API_KEY=your-api-key -- uvx elevenlabs-mcp';
+  
+  console.log(chalk.yellow('Run this command in your terminal:'));
+  console.log(chalk.white.bold(mcpCommand));
+  console.log();
+  
+  console.log(chalk.gray('This will:'));
+  console.log(chalk.gray('• Install the ElevenLabs MCP server'));
+  console.log(chalk.gray('• Configure it with your API key'));
+  console.log(chalk.gray('• Make it available in Claude Code'));
+  console.log();
+  
+  const runNow = await inquirer.prompt({
+    type: 'confirm',
+    name: 'run',
+    message: 'Would you like me to run this command now?',
+    default: false
+  });
+  
+  if (runNow.run) {
+    const spinner = ora('Setting up ElevenLabs MCP...').start();
+    try {
+      await execAsync(mcpCommand);
+      spinner.succeed('ElevenLabs MCP setup completed');
+    } catch (error) {
+      spinner.fail(`MCP setup failed: ${error.message}`);
+      console.log(chalk.yellow('You can run the command manually later.'));
+    }
+  }
+}
+
+async function saveSetupConfiguration(provider) {
+  const config = {
+    enabled: true,
+    provider: provider
+  };
+  
+  saveVoiceConfig(config);
+  
+  // Also save to .env for environment override capability
+  const envUpdates = {
+    CLAUDE_AGENTS_VOICE_ENABLED: 'true',
+    CLAUDE_AGENTS_VOICE_PROVIDER: provider
+  };
+  
+  saveEnv(envUpdates);
+  
+  console.log(chalk.green('✓ Voice configuration saved'));
+}
+
+async function testVoiceSetup() {
+  const testVoice = await inquirer.prompt({
+    type: 'confirm',
+    name: 'test',
+    message: 'Test voice setup now?',
+    default: true
+  });
+  
+  if (testVoice.test) {
+    await handleTest('Voice setup test completed successfully!');
+  }
+}
+
+async function checkFFmpegAvailable() {
+  try {
+    await execAsync('ffmpeg -version');
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+function getRequiredKeysForProvider(provider) {
+  const keyMap = {
+    auto: [
+      { key: 'OPENAI_API_KEY', name: 'OpenAI', required: false },
+      { key: 'ELEVENLABS_API_KEY', name: 'ElevenLabs', required: false },
+      { key: 'ANTHROPIC_API_KEY', name: 'Anthropic', required: false }
+    ],
+    mcp: [
+      { key: 'ELEVENLABS_API_KEY', name: 'ElevenLabs', required: true }
+    ],
+    elevenlabs: [
+      { key: 'ELEVENLABS_API_KEY', name: 'ElevenLabs', required: true }
+    ],
+    openai: [
+      { key: 'OPENAI_API_KEY', name: 'OpenAI', required: true }
+    ],
+    local: []
+  };
+  
+  return keyMap[provider] || [];
+}
+
+function getSetupRecommendations() {
+  const recommendations = [];
+  const config = getVoiceConfig();
+  
+  if (!config.enabled) {
+    recommendations.push('Enable voice with: claude-agents voice --enable');
+  }
+  
+  if (config.provider === 'local' && !hasApiKey('OPENAI_API_KEY') && !hasApiKey('ELEVENLABS_API_KEY')) {
+    recommendations.push('Consider adding API keys for better voice quality');
+  }
+  
+  if (config.provider === 'mcp' && !hasApiKey('ELEVENLABS_API_KEY')) {
+    recommendations.push('ElevenLabs API key needed for MCP integration');
+  }
+  
+  return recommendations;
+}
+
+async function handleEnable(enable) {
+  const config = getVoiceConfig();
+  config.enabled = enable;
+  
+  saveVoiceConfig({ enabled: enable });
+  
+  console.log(chalk.green('✓'), `Voice ${enable ? 'enabled' : 'disabled'} successfully`);
+  
+  if (enable && !hasAPIKeys()) {
+    console.log(chalk.yellow('\n⚠️  No API keys configured for voice providers'));
+    console.log(chalk.gray('Run "claude-agents voice --setup" for guided configuration'));
+  }
+}
+
+async function handleProvider(provider) {
+  const validProviders = ['auto', 'mcp', 'openai', 'local'];
+  
+  if (!validProviders.includes(provider)) {
+    console.error(chalk.red('✗'), `Invalid provider: ${provider}`);
+    console.log(chalk.gray('Valid providers:', validProviders.join(', ')));
+    return;
+  }
+  
+  saveVoiceConfig({ provider });
+  console.log(chalk.green('✓'), `Voice provider set to: ${provider}`);
+  
+  if (provider === 'mcp') {
+    console.log(chalk.cyan('\n📌 To use ElevenLabs MCP:'));
+    console.log(chalk.yellow('\nRun this command:'));
+    console.log(chalk.white.bold('claude mcp add ElevenLabs -e ELEVENLABS_API_KEY=your-api-key -- uvx elevenlabs-mcp'));
+    console.log();
+    console.log(chalk.gray('This will:'));
+    console.log(chalk.gray('• Install the ElevenLabs MCP server'));
+    console.log(chalk.gray('• Configure it with your API key'));
+    console.log(chalk.gray('• Make it available in Claude Code'));
+    console.log();
+    console.log(chalk.gray('After setup, the mcp__ElevenLabs__text_to_speech tool will be available'));
+  }
+}
+
+async function handleTest(text) {
+  const spinner = ora('Testing voice...').start();
+  const tts = getTTS();
+  
+  try {
+    const result = await tts.speak(text || 'Claude agents voice test successful!', { force: true });
+    
+    if (result.success) {
+      spinner.succeed(`Voice test successful using ${result.provider || 'default'} provider`);
+    } else {
+      spinner.fail(`Voice test failed: ${result.reason}`);
+    }
+  } catch (error) {
+    spinner.fail(`Voice test error: ${error.message}`);
+  }
+}
+
+async function handleAPIKey(provider) {
+  if (provider === true) {
+    // Interactive API key setup
+    const answers = await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'provider',
+        message: 'Select provider to configure:',
+        choices: [
+          { name: 'OpenAI', value: 'openai' }
+        ]
+      },
+      {
+        type: 'password',
+        name: 'apiKey',
+        message: 'Enter API key:',
+        mask: '*',
+        validate: input => input.trim() ? true : 'API key cannot be empty'
+      }
+    ]);
+    
+    saveAPIKey(answers.provider, answers.apiKey);
+    console.log(chalk.green('✓'), `${answers.provider} API key saved successfully`);
+  } else {
+    // Direct provider specified
+    console.log(chalk.yellow('Please use interactive mode: claude-agents voice --api-key'));
+  }
+}
+
+async function showInteractiveMenu() {
+  const config = getVoiceConfig();
+  const apiKeys = getAPIKeys();
+  
+  console.log(chalk.bold.blue('\n🔊 Voice Configuration\n'));
+  
+  console.log(chalk.bold('Current Settings:'));
+  console.log(chalk.gray('├─'), 'Status:', config.enabled ? chalk.green('Enabled') : chalk.red('Disabled'));
+  console.log(chalk.gray('├─'), 'Provider:', chalk.cyan(config.provider));
+  console.log(chalk.gray('├─'), 'OpenAI API:', hasApiKey('OPENAI_API_KEY') ? chalk.green('Configured') : chalk.gray('Not set'));
+  console.log(chalk.gray('├─'), 'Anthropic API:', hasApiKey('ANTHROPIC_API_KEY') ? chalk.green('Configured') : chalk.gray('Not set'));
+  console.log(chalk.gray('├─'), 'ElevenLabs API:', hasApiKey('ELEVENLABS_API_KEY') ? chalk.green('Configured') : chalk.gray('Not set'));
+  console.log(chalk.gray('└─'), 'Engineer Name:', getEnvVar('ENGINEER_NAME') || chalk.gray('Not set'));
+  
+  const choices = [
+    { name: config.enabled ? 'Disable voice' : 'Enable voice', value: 'toggle' },
+    { name: 'Run setup wizard', value: 'setup' },
+    { name: 'Show system status', value: 'status' },
+    { name: 'Change provider', value: 'provider' },
+    { name: 'Configure API keys', value: 'apikeys' },
+    { name: 'Test voice', value: 'test' },
+    { name: 'View announcements settings', value: 'announcements' },
+    new inquirer.Separator(),
+    { name: 'Exit', value: 'exit' }
+  ];
+  
+  const answer = await inquirer.prompt({
+    type: 'list',
+    name: 'action',
+    message: 'What would you like to do?',
+    choices
+  });
+  
+  switch (answer.action) {
+    case 'toggle':
+      await handleEnable(!config.enabled);
+      break;
+      
+    case 'setup':
+      await handleSetup();
+      break;
+      
+    case 'status':
+      await handleStatus();
+      break;
+      
+    case 'provider':
+      const providerAnswer = await inquirer.prompt({
+        type: 'list',
+        name: 'provider',
+        message: 'Select voice provider:',
+        choices: [
+          { name: 'Auto (best available)', value: 'auto' },
+          { name: 'ElevenLabs (via Claude Code MCP)', value: 'mcp' },
+          { name: 'OpenAI', value: 'openai' },
+          { name: 'Local (system TTS)', value: 'local' }
+        ],
+        default: config.provider
+      });
+      await handleProvider(providerAnswer.provider);
+      break;
+      
+    case 'apikeys':
+      await handleAPIKey(true);
+      break;
+      
+    case 'test':
+      await handleTest();
+      break;
+      
+    case 'announcements':
+      await configureAnnouncements();
+      break;
+  }
+}
+
+async function configureAnnouncements() {
+  const config = getVoiceConfig();
+  
+  const answers = await inquirer.prompt([
+    {
+      type: 'checkbox',
+      name: 'announcements',
+      message: 'Select which events should trigger voice announcements:',
+      choices: [
+        { name: 'Agent start', value: 'agentStart', checked: config.announcements.agentStart },
+        { name: 'Agent complete', value: 'agentComplete', checked: config.announcements.agentComplete },
+        { name: 'Errors', value: 'errors', checked: config.announcements.errors },
+        { name: 'Progress updates', value: 'progress', checked: config.announcements.progress }
+      ]
+    }
+  ]);
+  
+  const announcements = {
+    agentStart: answers.announcements.includes('agentStart'),
+    agentComplete: answers.announcements.includes('agentComplete'),
+    errors: answers.announcements.includes('errors'),
+    progress: answers.announcements.includes('progress')
+  };
+  
+  saveVoiceConfig({ announcements });
+  console.log(chalk.green('✓'), 'Announcement settings updated');
+}
+
+function hasAPIKeys() {
+  return hasApiKey('OPENAI_API_KEY') || hasApiKey('ELEVENLABS_API_KEY') || hasApiKey('ANTHROPIC_API_KEY');
+}

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,10 @@ import { runCommand } from './commands/run.js';
 import { dashboardCommand } from './commands/dashboard.js';
 import { initCommand } from './commands/init.js';
 import { uninstallCommand } from './commands/uninstall.js';
+import { voiceCommand } from './commands/voice.js';
+import { chainCommand } from './commands/chain.js';
+import { setupCommand } from './commands/setup.js';
+import { diagnoseCommand } from './commands/diagnose.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -46,6 +50,7 @@ program
   .option('--merge', 'Merge with existing CLAUDE.md (default: true)')
   .option('--no-merge', 'Do not modify existing CLAUDE.md')
   .option('--force', 'Overwrite existing files')
+  .option('--no-hooks', 'Skip Claude Code hooks installation')
   .action(initCommand);
 
 // Install command
@@ -117,6 +122,8 @@ program
   .option('-t, --task <task>', 'Task description for the agent')
   .option('-f, --file <file>', 'Target file or directory')
   .option('-i, --interactive', 'Interactive mode for task input')
+  .option('--voice', 'Enable voice announcements')
+  .option('--no-voice', 'Disable voice announcements')
   .action(runCommand);
 
 // Update command
@@ -135,6 +142,46 @@ program
   .option('-p, --port <port>', 'Dashboard port', '7842')
   .option('--no-browser', "Don't open browser automatically")
   .action(dashboardCommand);
+
+// Voice command
+program
+  .command('voice')
+  .description('Configure voice announcements')
+  .option('--setup', 'Run interactive setup wizard')
+  .option('--status', 'Show voice system status')
+  .option('--enable', 'Enable voice announcements')
+  .option('--disable', 'Disable voice announcements')
+  .option('--provider <provider>', 'Set voice provider (auto, mcp, openai, local)')
+  .option('--test [text]', 'Test voice with optional text')
+  .option('--api-key', 'Configure API keys interactively')
+  .action(voiceCommand);
+
+// Chain command
+program
+  .command('chain <nameOrAgents...>')
+  .description('Run agents in sequence or parallel')
+  .option('--task <task>', 'Task description for all agents')
+  .option('--tasks <tasks...>', 'Individual tasks for each agent')
+  .option('--voice', 'Enable voice announcements')
+  .option('--isolated', 'Run agents in isolated mode')
+  .option('--concurrent', 'Run agents concurrently where possible')
+  .option('--save <name>', 'Save as a reusable chain')
+  .action(chainCommand);
+
+// Setup command
+program
+  .command('setup')
+  .description('Interactive setup wizard for agents, voice, and API keys')
+  .option('--agents-only', 'Configure only agents')
+  .option('--voice-only', 'Configure only voice settings')
+  .option('--keys-only', 'Configure only API keys')
+  .action(setupCommand);
+
+// Diagnose command
+program
+  .command('diagnose')
+  .description('Diagnose installation issues and check hook health')
+  .action(diagnoseCommand);
 
 // Config command
 program

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
 import { getConfigPath } from './paths.js';
 
 export const DEFAULT_CONFIG = {
@@ -10,7 +11,20 @@ export const DEFAULT_CONFIG = {
     autoEnableOnInstall: true,
     preferProjectScope: false,
     autoUpdateCheck: true
-  }
+  },
+  voice: {
+    enabled: false,
+    provider: 'auto', // auto, mcp, openai, local
+    announcements: {
+      agentStart: false,
+      agentComplete: true,
+      errors: true,
+      progress: false
+    },
+    autoCleanup: true,    // Auto-delete audio files after playback
+    cleanupDelay: 15000   // Wait 15 seconds before cleanup
+  },
+  api_keys: {}
 };
 
 export function loadConfig(isProject = false) {
@@ -125,4 +139,103 @@ export function getInstalledAgents(checkBothScopes = true) {
   }
   
   return agents;
+}
+
+// Voice configuration functions
+export function getVoiceConfig(isProject = false, projectPath = process.cwd()) {
+  const config = loadConfig(isProject);
+  const envVars = loadEnvFile(projectPath);
+  
+  // Merge with environment variable overrides
+  const voiceConfig = { ...config.voice };
+  
+  // Check process.env first, then .env file, then config
+  const voiceEnabled = process.env.CLAUDE_AGENTS_VOICE_ENABLED || 
+                      envVars.CLAUDE_AGENTS_VOICE_ENABLED;
+  if (voiceEnabled !== undefined) {
+    voiceConfig.enabled = voiceEnabled === 'true';
+  }
+  
+  const voiceProvider = process.env.CLAUDE_AGENTS_VOICE_PROVIDER || 
+                       envVars.CLAUDE_AGENTS_VOICE_PROVIDER;
+  if (voiceProvider) {
+    voiceConfig.provider = voiceProvider;
+  }
+  
+  return voiceConfig;
+}
+
+export function saveVoiceConfig(voiceUpdates, isProject = false) {
+  const config = loadConfig(isProject);
+  
+  config.voice = {
+    ...config.voice,
+    ...voiceUpdates
+  };
+  
+  return saveConfig(config, isProject);
+}
+
+/**
+ * Load environment variables from .env file if present
+ */
+function loadEnvFile(projectPath = process.cwd()) {
+  const envPath = join(projectPath, '.env');
+  
+  if (!existsSync(envPath)) {
+    return {};
+  }
+  
+  try {
+    const content = readFileSync(envPath, 'utf-8');
+    const envVars = {};
+    
+    content.split('\n').forEach(line => {
+      const trimmedLine = line.trim();
+      if (trimmedLine && !trimmedLine.startsWith('#')) {
+        const [key, ...valueParts] = trimmedLine.split('=');
+        if (key && valueParts.length > 0) {
+          const value = valueParts.join('=').trim();
+          // Remove quotes if present
+          envVars[key.trim()] = value.replace(/^["']|["']$/g, '');
+        }
+      }
+    });
+    
+    return envVars;
+  } catch (error) {
+    console.warn('Warning: Failed to load .env file:', error.message);
+    return {};
+  }
+}
+
+export function getAPIKeys(projectPath = process.cwd()) {
+  const userConfig = loadConfig(false);
+  const envVars = loadEnvFile(projectPath);
+  
+  return {
+    anthropic: process.env.ANTHROPIC_API_KEY || envVars.ANTHROPIC_API_KEY || userConfig.api_keys?.anthropic,
+    elevenlabs: process.env.ELEVENLABS_API_KEY || envVars.ELEVENLABS_API_KEY || userConfig.api_keys?.elevenlabs,
+    openai: process.env.OPENAI_API_KEY || envVars.OPENAI_API_KEY || userConfig.api_keys?.openai,
+    deepseek: process.env.DEEPSEEK_API_KEY || envVars.DEEPSEEK_API_KEY || userConfig.api_keys?.deepseek,
+    gemini: process.env.GEMINI_API_KEY || envVars.GEMINI_API_KEY || userConfig.api_keys?.gemini,
+    groq: process.env.GROQ_API_KEY || envVars.GROQ_API_KEY || userConfig.api_keys?.groq,
+    firecrawl: process.env.FIRECRAWL_API_KEY || envVars.FIRECRAWL_API_KEY || userConfig.api_keys?.firecrawl
+  };
+}
+
+export function saveAPIKey(provider, apiKey) {
+  const config = loadConfig(false);
+  
+  if (!config.api_keys) {
+    config.api_keys = {};
+  }
+  
+  if (apiKey) {
+    config.api_keys[provider] = apiKey;
+  } else {
+    delete config.api_keys[provider];
+  }
+  
+  return saveConfig(config, false);
 }

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,0 +1,232 @@
+import { readFileSync, writeFileSync, existsSync, copyFileSync, unlinkSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+const ENV_PATH = join(process.cwd(), '.env');
+const ENV_BACKUP_PATH = join(process.cwd(), '.env.backup');
+
+/**
+ * Load environment variables from .env file
+ * @returns {Object} Parsed environment variables
+ */
+export function loadEnv() {
+  const env = {};
+  
+  if (!existsSync(ENV_PATH)) {
+    return env;
+  }
+  
+  try {
+    const content = readFileSync(ENV_PATH, 'utf-8');
+    const lines = content.split('\n');
+    
+    for (const line of lines) {
+      const trimmed = line.trim();
+      
+      // Skip empty lines and comments
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+      
+      // Parse key=value
+      const index = trimmed.indexOf('=');
+      if (index > 0) {
+        const key = trimmed.substring(0, index).trim();
+        const value = trimmed.substring(index + 1).trim();
+        
+        // Remove quotes if present
+        env[key] = value.replace(/^["']|["']$/g, '');
+      }
+    }
+  } catch (error) {
+    console.error('Error reading .env file:', error.message);
+  }
+  
+  return env;
+}
+
+/**
+ * Save environment variables to .env file
+ * @param {Object} updates - Key-value pairs to update/add
+ * @param {boolean} merge - Whether to merge with existing values (default: true)
+ */
+export function saveEnv(updates, merge = true) {
+  let env = {};
+  let existingLines = [];
+  let hasExistingContent = false;
+  
+  // Read existing file if merging
+  if (merge && existsSync(ENV_PATH)) {
+    hasExistingContent = true;
+    const content = readFileSync(ENV_PATH, 'utf-8');
+    existingLines = content.split('\n');
+    env = loadEnv();
+  }
+  
+  // Apply updates
+  env = { ...env, ...updates };
+  
+  // Build new content preserving comments and structure
+  const newLines = [];
+  const processedKeys = new Set();
+  
+  if (hasExistingContent) {
+    // Process existing lines, updating values where needed
+    for (const line of existingLines) {
+      const trimmed = line.trim();
+      
+      // Preserve empty lines and comments
+      if (!trimmed || trimmed.startsWith('#')) {
+        newLines.push(line);
+        continue;
+      }
+      
+      // Check if this is a key=value line
+      const index = trimmed.indexOf('=');
+      if (index > 0) {
+        const key = trimmed.substring(0, index).trim();
+        
+        if (key in updates) {
+          // Update existing key
+          newLines.push(`${key}=${updates[key]}`);
+          processedKeys.add(key);
+        } else {
+          // Preserve existing line
+          newLines.push(line);
+        }
+      } else {
+        // Preserve non-key-value lines
+        newLines.push(line);
+      }
+    }
+  }
+  
+  // Add new keys that weren't in the original file
+  const newKeys = Object.keys(updates).filter(key => !processedKeys.has(key));
+  
+  if (newKeys.length > 0) {
+    // Add section separator if file has content
+    if (newLines.length > 0 && !newLines[newLines.length - 1].trim().startsWith('#')) {
+      newLines.push('');
+      newLines.push('# Added by claude-agents setup');
+    }
+    
+    for (const key of newKeys) {
+      if (updates[key] !== undefined && updates[key] !== null) {
+        newLines.push(`${key}=${updates[key]}`);
+      }
+    }
+  }
+  
+  // Ensure file ends with newline
+  if (newLines.length > 0 && newLines[newLines.length - 1] !== '') {
+    newLines.push('');
+  }
+  
+  // Write the file
+  writeFileSync(ENV_PATH, newLines.join('\n'));
+}
+
+/**
+ * Create a backup of the current .env file
+ * @returns {boolean} True if backup was created
+ */
+export function backupEnv() {
+  if (!existsSync(ENV_PATH)) {
+    return false;
+  }
+  
+  try {
+    // Create timestamped backup
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const backupPath = join(process.cwd(), `.env.backup-${timestamp}`);
+    copyFileSync(ENV_PATH, backupPath);
+    
+    // Also create/update the simple backup
+    copyFileSync(ENV_PATH, ENV_BACKUP_PATH);
+    
+    // Clean old backups (keep last 5)
+    cleanOldBackups();
+    
+    return true;
+  } catch (error) {
+    console.error('Error creating backup:', error.message);
+    return false;
+  }
+}
+
+/**
+ * Restore .env from backup
+ * @returns {boolean} True if restore was successful
+ */
+export function restoreEnv() {
+  if (!existsSync(ENV_BACKUP_PATH)) {
+    return false;
+  }
+  
+  try {
+    copyFileSync(ENV_BACKUP_PATH, ENV_PATH);
+    return true;
+  } catch (error) {
+    console.error('Error restoring backup:', error.message);
+    return false;
+  }
+}
+
+/**
+ * Clean old backup files, keeping only the most recent ones
+ * @param {number} keepCount - Number of backups to keep (default: 5)
+ */
+function cleanOldBackups(keepCount = 5) {
+  try {
+    const files = readdirSync(process.cwd());
+    const backupFiles = files
+      .filter(f => f.startsWith('.env.backup-') && f.includes('T'))
+      .sort()
+      .reverse();
+    
+    // Remove old backups
+    for (let i = keepCount; i < backupFiles.length; i++) {
+      try {
+        unlinkSync(join(process.cwd(), backupFiles[i]));
+      } catch (error) {
+        // Ignore errors for individual file deletions
+      }
+    }
+  } catch (error) {
+    // Ignore errors in cleanup
+  }
+}
+
+/**
+ * Get a specific environment variable value
+ * @param {string} key - Environment variable key
+ * @param {string} defaultValue - Default value if not found
+ * @returns {string} The environment variable value
+ */
+export function getEnvVar(key, defaultValue = '') {
+  const env = loadEnv();
+  return env[key] || process.env[key] || defaultValue;
+}
+
+/**
+ * Check if an API key is configured
+ * @param {string} key - Environment variable key
+ * @returns {boolean} True if the key exists and has a value
+ */
+export function hasApiKey(key) {
+  const value = getEnvVar(key);
+  return value && value.trim() !== '';
+}
+
+/**
+ * Get all configured API keys
+ * @returns {Object} Object with API key status
+ */
+export function getApiKeyStatus() {
+  return {
+    openai: hasApiKey('OPENAI_API_KEY'),
+    anthropic: hasApiKey('ANTHROPIC_API_KEY'),
+    elevenlabs: hasApiKey('ELEVENLABS_API_KEY'),
+    engineerName: getEnvVar('ENGINEER_NAME', '')
+  };
+}

--- a/src/utils/handoff.js
+++ b/src/utils/handoff.js
@@ -1,0 +1,164 @@
+/**
+ * Agent Handoff Utilities
+ * 
+ * Manages lightweight data transfer between agents
+ * to preserve context windows
+ */
+
+import { getMemoryStore } from '../memory/index.js';
+
+/**
+ * Store handoff data between agents
+ * @param {string} fromAgent - Source agent name
+ * @param {string} toAgent - Target agent name (use '*' for any)
+ * @param {string} dataType - Type of data being passed
+ * @param {any} data - The actual data (keep minimal!)
+ * @param {string} summary - Brief summary for orchestrator
+ * @param {number} ttl - Time to live in ms (default: 1 hour)
+ */
+export function createHandoff(fromAgent, toAgent, dataType, data, summary, ttl = 3600000) {
+  const memory = getMemoryStore();
+  const handoffKey = `handoff:${fromAgent}:${toAgent}:${dataType}`;
+  
+  const handoff = {
+    task_id: `task-${Date.now()}`,
+    from: fromAgent,
+    to: toAgent,
+    type: dataType,
+    data: data,
+    summary: summary,
+    timestamp: new Date().toISOString()
+  };
+  
+  memory.set(handoffKey, handoff, ttl);
+  
+  // Also store a reference for the target agent to find
+  if (toAgent !== '*') {
+    memory.set(`pending:${toAgent}:${dataType}`, handoffKey, ttl);
+  }
+  
+  return handoff;
+}
+
+/**
+ * Retrieve handoff data for an agent
+ * @param {string} agentName - Agent looking for inputs
+ * @param {string} dataType - Type of data needed
+ * @returns {Object|null} Handoff data or null
+ */
+export function getHandoff(agentName, dataType) {
+  const memory = getMemoryStore();
+  
+  // Check if there's a pending handoff for this agent
+  const pendingKey = memory.get(`pending:${agentName}:${dataType}`);
+  if (pendingKey) {
+    const handoff = memory.get(pendingKey);
+    // Clean up the pending reference
+    memory.delete(`pending:${agentName}:${dataType}`);
+    return handoff;
+  }
+  
+  // Look for any handoff to this agent or wildcard
+  const patterns = [
+    `handoff:*:${agentName}:${dataType}`,
+    `handoff:*:*:${dataType}`
+  ];
+  
+  for (const pattern of patterns) {
+    const keys = memory.keys(pattern);
+    if (keys.length > 0) {
+      // Get the most recent handoff
+      const handoffs = keys.map(key => memory.get(key))
+        .filter(h => h !== null)
+        .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+      
+      if (handoffs.length > 0) {
+        return handoffs[0];
+      }
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Get all available handoffs for an agent
+ * @param {string} agentName - Agent name
+ * @returns {Array} Array of available handoffs
+ */
+export function getAvailableHandoffs(agentName) {
+  const memory = getMemoryStore();
+  const handoffs = [];
+  
+  // Get all pending handoffs
+  const pendingPattern = `pending:${agentName}:*`;
+  const pendingKeys = memory.keys(pendingPattern);
+  
+  for (const pendingKey of pendingKeys) {
+    const handoffKey = memory.get(pendingKey);
+    const handoff = memory.get(handoffKey);
+    if (handoff) {
+      handoffs.push(handoff);
+    }
+  }
+  
+  return handoffs;
+}
+
+/**
+ * Create a handoff summary for the orchestrator
+ * @param {string} agent - Agent name
+ * @param {string} task - Task description
+ * @param {Object} result - Task result
+ * @returns {string} Brief summary
+ */
+export function createSummary(agent, task, result) {
+  // Keep summaries under 100 characters for context efficiency
+  const status = result.success ? '✓' : '✗';
+  const key = result.output_type || 'result';
+  
+  return `${status} ${agent}: ${task.substring(0, 50)}... → ${key}`;
+}
+
+/**
+ * Parse agent metadata to get consumes/produces
+ * @param {Object} metadata - Agent metadata
+ * @returns {Object} Input/output configuration
+ */
+export function getAgentIO(metadata) {
+  return {
+    consumes: metadata.consumes || [],
+    produces: metadata.produces || [],
+    optional_inputs: metadata.optional_inputs || []
+  };
+}
+
+/**
+ * Check if an agent can consume certain data types
+ * @param {Object} metadata - Agent metadata
+ * @param {Array} availableTypes - Available data types
+ * @returns {boolean} Whether agent can proceed
+ */
+export function canAgentProceed(metadata, availableTypes) {
+  const io = getAgentIO(metadata);
+  
+  // Check if all required inputs are available
+  return io.consumes.every(required => 
+    availableTypes.includes(required)
+  );
+}
+
+/**
+ * Format handoff data for agent consumption
+ * @param {Array} handoffs - Array of handoff objects
+ * @returns {Object} Formatted input data
+ */
+export function formatHandoffInputs(handoffs) {
+  const inputs = {};
+  
+  for (const handoff of handoffs) {
+    inputs[handoff.type] = handoff.data;
+  }
+  
+  return inputs;
+}

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -1,0 +1,1018 @@
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+
+export async function createHookFiles(hooksDir, hooksLlmDir, hooksTtsDir) {
+  const files = {};
+  
+  // Create subagent_stop.py
+  files.subagentStop = join(hooksDir, 'subagent_stop.py');
+  writeFileSync(files.subagentStop, getSubagentStopScript());
+  
+  // Create stop.py
+  files.stop = join(hooksDir, 'stop.py');
+  writeFileSync(files.stop, getStopScript());
+  
+  // Create LLM utilities
+  files.oai = join(hooksLlmDir, 'oai.py');
+  writeFileSync(files.oai, getOaiScript());
+  
+  files.anth = join(hooksLlmDir, 'anth.py');
+  writeFileSync(files.anth, getAnthScript());
+  
+  // Create TTS utilities
+  files.elevenlabsMcp = join(hooksTtsDir, 'elevenlabs_mcp.py');
+  writeFileSync(files.elevenlabsMcp, getElevenlabsMcpScript());
+  
+  files.openaiTts = join(hooksTtsDir, 'openai_tts.py');
+  writeFileSync(files.openaiTts, getOpenaiTtsScript());
+  
+  files.localTts = join(hooksTtsDir, 'local_tts.py');
+  writeFileSync(files.localTts, getLocalTtsScript());
+  
+  return files;
+}
+
+export function createSettingsTemplate(projectPath = null) {
+  // If projectPath is provided, use absolute paths, otherwise use relative
+  const hookPath = projectPath ? `${projectPath}/.claude/hooks` : '.claude/hooks';
+  
+  return JSON.stringify({
+    "permissions": {
+      "allow": [
+        "Bash(mkdir:*)",
+        "Bash(uv:*)",
+        "Bash(find:*)",
+        "Bash(mv:*)",
+        "Bash(grep:*)",
+        "Bash(npm:*)",
+        "Bash(ls:*)",
+        "Bash(cp:*)",
+        "Write",
+        "Edit",
+        "Bash(chmod:*)",
+        "Bash(touch:*)"
+      ],
+      "deny": []
+    },
+    "hooks": {
+      "Stop": [
+        {
+          "matcher": "",
+          "hooks": [
+            {
+              "type": "command",
+              "command": `python3 ${hookPath}/stop.py --chat`
+            }
+          ]
+        }
+      ],
+      "SubagentStop": [
+        {
+          "matcher": "",
+          "hooks": [
+            {
+              "type": "command",
+              "command": `python3 ${hookPath}/subagent_stop.py`
+            }
+          ]
+        }
+      ]
+    }
+  }, null, 2);
+}
+
+function getSubagentStopScript() {
+  return `#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-dotenv",
+# ]
+# ///
+
+import argparse
+import json
+import os
+import sys
+import subprocess
+from pathlib import Path
+from datetime import datetime
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass  # dotenv is optional
+
+
+def get_tts_script_path():
+    """
+    Determine which TTS script to use based on available API keys and MCP.
+    Priority order: ElevenLabs MCP > OpenAI > local
+    """
+    # Get current script directory and construct utils/tts path
+    script_dir = Path(__file__).parent
+    tts_dir = script_dir / "utils" / "tts"
+    
+    # Check for ElevenLabs MCP first (highest priority)
+    elevenlabs_mcp_script = tts_dir / "elevenlabs_mcp.py"
+    if elevenlabs_mcp_script.exists():
+        return str(elevenlabs_mcp_script)
+    
+    # Check for OpenAI API key (second priority)
+    if os.getenv('OPENAI_API_KEY'):
+        openai_script = tts_dir / "openai_tts.py"
+        if openai_script.exists():
+            return str(openai_script)
+    
+    # Fall back to local TTS (no API key required)
+    local_script = tts_dir / "local_tts.py"
+    if local_script.exists():
+        return str(local_script)
+    
+    return None
+
+
+def announce_subagent_completion():
+    """Announce subagent completion using the best available TTS service."""
+    try:
+        tts_script = get_tts_script_path()
+        if not tts_script:
+            return  # No TTS scripts available
+        
+        # Use fixed message for subagent completion
+        completion_message = "Subagent Complete"
+        
+        # Call the TTS script with the completion message
+        subprocess.run([
+            "uv", "run", tts_script, completion_message
+        ], 
+        capture_output=True,  # Suppress output
+        timeout=10  # 10-second timeout
+        )
+        
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, FileNotFoundError):
+        # Fail silently if TTS encounters issues
+        pass
+    except Exception:
+        # Fail silently for any other errors
+        pass
+
+
+def main():
+    try:
+        # Parse command line arguments
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--chat', action='store_true', help='Copy transcript to chat.json')
+        args = parser.parse_args()
+        
+        # Read JSON input from stdin
+        input_data = json.load(sys.stdin)
+
+        # Extract required fields
+        session_id = input_data.get("session_id", "")
+        stop_hook_active = input_data.get("stop_hook_active", False)
+
+        # Ensure log directory exists
+        log_dir = os.path.join(os.getcwd(), "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        log_path = os.path.join(log_dir, "subagent_stop.json")
+
+        # Read existing log data or initialize empty list
+        if os.path.exists(log_path):
+            with open(log_path, 'r') as f:
+                try:
+                    log_data = json.load(f)
+                except (json.JSONDecodeError, ValueError):
+                    log_data = []
+        else:
+            log_data = []
+        
+        # Append new data
+        log_data.append(input_data)
+        
+        # Write back to file with formatting
+        with open(log_path, 'w') as f:
+            json.dump(log_data, f, indent=2)
+        
+        # Handle --chat switch (same as stop.py)
+        if args.chat and 'transcript_path' in input_data:
+            transcript_path = input_data['transcript_path']
+            if os.path.exists(transcript_path):
+                # Read .jsonl file and convert to JSON array
+                chat_data = []
+                try:
+                    with open(transcript_path, 'r') as f:
+                        for line in f:
+                            line = line.strip()
+                            if line:
+                                try:
+                                    chat_data.append(json.loads(line))
+                                except json.JSONDecodeError:
+                                    pass  # Skip invalid lines
+                    
+                    # Write to logs/chat.json
+                    chat_file = os.path.join(log_dir, 'chat.json')
+                    with open(chat_file, 'w') as f:
+                        json.dump(chat_data, f, indent=2)
+                except Exception:
+                    pass  # Fail silently
+
+        # Announce subagent completion via TTS
+        announce_subagent_completion()
+
+        sys.exit(0)
+
+    except json.JSONDecodeError:
+        # Handle JSON decode errors gracefully
+        sys.exit(0)
+    except Exception:
+        # Handle any other errors gracefully
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()
+`;
+}
+
+function getStopScript() {
+  return `#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-dotenv",
+# ]
+# ///
+
+import argparse
+import json
+import os
+import sys
+import random
+import subprocess
+from pathlib import Path
+from datetime import datetime
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass  # dotenv is optional
+
+
+def get_completion_messages():
+    """Return list of friendly completion messages."""
+    return [
+        "Work complete!",
+        "All done!",
+        "Task finished!",
+        "Job complete!",
+        "Ready for next task!"
+    ]
+
+
+def get_tts_script_path():
+    """
+    Determine which TTS script to use based on available API keys and MCP.
+    Priority order: ElevenLabs MCP > OpenAI > local
+    """
+    # Get current script directory and construct utils/tts path
+    script_dir = Path(__file__).parent
+    tts_dir = script_dir / "utils" / "tts"
+    
+    # Check for ElevenLabs MCP first (highest priority)
+    elevenlabs_mcp_script = tts_dir / "elevenlabs_mcp.py"
+    if elevenlabs_mcp_script.exists():
+        return str(elevenlabs_mcp_script)
+    
+    # Check for OpenAI API key (second priority)
+    if os.getenv('OPENAI_API_KEY'):
+        openai_script = tts_dir / "openai_tts.py"
+        if openai_script.exists():
+            return str(openai_script)
+    
+    # Fall back to local TTS (no API key required)
+    local_script = tts_dir / "local_tts.py"
+    if local_script.exists():
+        return str(local_script)
+    
+    return None
+
+
+def get_llm_completion_message():
+    """
+    Generate completion message using available LLM services.
+    Priority order: OpenAI > Anthropic > fallback to random message
+    
+    Returns:
+        str: Generated or fallback completion message
+    """
+    # Get current script directory and construct utils/llm path
+    script_dir = Path(__file__).parent
+    llm_dir = script_dir / "utils" / "llm"
+    
+    # Try OpenAI first (highest priority)
+    if os.getenv('OPENAI_API_KEY'):
+        oai_script = llm_dir / "oai.py"
+        if oai_script.exists():
+            try:
+                result = subprocess.run([
+                    "uv", "run", str(oai_script), "--completion"
+                ], 
+                capture_output=True,
+                text=True,
+                timeout=10
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    return result.stdout.strip()
+            except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+                pass
+    
+    # Try Anthropic second
+    if os.getenv('ANTHROPIC_API_KEY'):
+        anth_script = llm_dir / "anth.py"
+        if anth_script.exists():
+            try:
+                result = subprocess.run([
+                    "uv", "run", str(anth_script), "--completion"
+                ], 
+                capture_output=True,
+                text=True,
+                timeout=10
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    return result.stdout.strip()
+            except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+                pass
+    
+    # Fallback to random predefined message
+    messages = get_completion_messages()
+    return random.choice(messages)
+
+def announce_completion():
+    """Announce completion using the best available TTS service."""
+    try:
+        tts_script = get_tts_script_path()
+        if not tts_script:
+            return  # No TTS scripts available
+        
+        # Get completion message (LLM-generated or fallback)
+        completion_message = get_llm_completion_message()
+        
+        # Call the TTS script with the completion message
+        subprocess.run([
+            "uv", "run", tts_script, completion_message
+        ], 
+        capture_output=True,  # Suppress output
+        timeout=10  # 10-second timeout
+        )
+        
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, FileNotFoundError):
+        # Fail silently if TTS encounters issues
+        pass
+    except Exception:
+        # Fail silently for any other errors
+        pass
+
+
+def main():
+    try:
+        # Parse command line arguments
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--chat', action='store_true', help='Copy transcript to chat.json')
+        args = parser.parse_args()
+        
+        # Read JSON input from stdin
+        input_data = json.load(sys.stdin)
+
+        # Extract required fields
+        session_id = input_data.get("session_id", "")
+        stop_hook_active = input_data.get("stop_hook_active", False)
+
+        # Ensure log directory exists
+        log_dir = os.path.join(os.getcwd(), "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        log_path = os.path.join(log_dir, "stop.json")
+
+        # Read existing log data or initialize empty list
+        if os.path.exists(log_path):
+            with open(log_path, 'r') as f:
+                try:
+                    log_data = json.load(f)
+                except (json.JSONDecodeError, ValueError):
+                    log_data = []
+        else:
+            log_data = []
+        
+        # Append new data
+        log_data.append(input_data)
+        
+        # Write back to file with formatting
+        with open(log_path, 'w') as f:
+            json.dump(log_data, f, indent=2)
+        
+        # Handle --chat switch
+        if args.chat and 'transcript_path' in input_data:
+            transcript_path = input_data['transcript_path']
+            if os.path.exists(transcript_path):
+                # Read .jsonl file and convert to JSON array
+                chat_data = []
+                try:
+                    with open(transcript_path, 'r') as f:
+                        for line in f:
+                            line = line.strip()
+                            if line:
+                                try:
+                                    chat_data.append(json.loads(line))
+                                except json.JSONDecodeError:
+                                    pass  # Skip invalid lines
+                    
+                    # Write to logs/chat.json
+                    chat_file = os.path.join(log_dir, 'chat.json')
+                    with open(chat_file, 'w') as f:
+                        json.dump(chat_data, f, indent=2)
+                except Exception:
+                    pass  # Fail silently
+
+        # Announce completion via TTS
+        announce_completion()
+
+        sys.exit(0)
+
+    except json.JSONDecodeError:
+        # Handle JSON decode errors gracefully
+        sys.exit(0)
+    except Exception:
+        # Handle any other errors gracefully
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()
+`;
+}
+
+function getOaiScript() {
+  return `#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "openai",
+#     "python-dotenv",
+# ]
+# ///
+
+import os
+import sys
+from dotenv import load_dotenv
+
+
+def prompt_llm(prompt_text):
+    """
+    Base OpenAI LLM prompting method using fastest model.
+
+    Args:
+        prompt_text (str): The prompt to send to the model
+
+    Returns:
+        str: The model's response text, or None if error
+    """
+    load_dotenv()
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+
+    try:
+        from openai import OpenAI
+
+        client = OpenAI(api_key=api_key)
+
+        response = client.chat.completions.create(
+            model="gpt-4o-mini",  # Fast OpenAI model
+            messages=[{"role": "user", "content": prompt_text}],
+            max_tokens=100,
+            temperature=0.7,
+        )
+
+        return response.choices[0].message.content.strip()
+
+    except Exception:
+        return None
+
+
+def generate_completion_message():
+    """
+    Generate a completion message using OpenAI LLM.
+
+    Returns:
+        str: A natural language completion message, or None if error
+    """
+    engineer_name = os.getenv("ENGINEER_NAME", "").strip()
+
+    if engineer_name:
+        name_instruction = f"Sometimes (about 30% of the time) include the engineer's name '{engineer_name}' in a natural way."
+        examples = f"""Examples of the style: 
+- Standard: "Work complete!", "All done!", "Task finished!", "Ready for your next move!"
+- Personalized: "{engineer_name}, all set!", "Ready for you, {engineer_name}!", "Complete, {engineer_name}!", "{engineer_name}, we're done!" """
+    else:
+        name_instruction = ""
+        examples = """Examples of the style: "Work complete!", "All done!", "Task finished!", "Ready for your next move!" """
+
+    prompt = f"""Generate a short, friendly completion message for when an AI coding assistant finishes a task. 
+
+Requirements:
+- Keep it under 10 words
+- Make it positive and future focused
+- Use natural, conversational language
+- Focus on completion/readiness
+- Do NOT include quotes, formatting, or explanations
+- Return ONLY the completion message text
+{name_instruction}
+
+{examples}
+
+Generate ONE completion message:"""
+
+    response = prompt_llm(prompt)
+
+    # Clean up response - remove quotes and extra formatting
+    if response:
+        response = response.strip().strip('"').strip("'").strip()
+        # Take first line if multiple lines
+        response = response.split("\\n")[0].strip()
+
+    return response
+
+
+def main():
+    """Command line interface for testing."""
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "--completion":
+            message = generate_completion_message()
+            if message:
+                print(message)
+            else:
+                print("Error generating completion message")
+        else:
+            prompt_text = " ".join(sys.argv[1:])
+            response = prompt_llm(prompt_text)
+            if response:
+                print(response)
+            else:
+                print("Error calling OpenAI API")
+    else:
+        print("Usage: ./oai.py 'your prompt here' or ./oai.py --completion")
+
+
+if __name__ == "__main__":
+    main()
+`;
+}
+
+function getAnthScript() {
+  return `#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "anthropic",
+#     "python-dotenv",
+# ]
+# ///
+
+import os
+import sys
+from dotenv import load_dotenv
+
+
+def prompt_llm(prompt_text):
+    """
+    Base Anthropic LLM prompting method using fastest model.
+
+    Args:
+        prompt_text (str): The prompt to send to the model
+
+    Returns:
+        str: The model's response text, or None if error
+    """
+    load_dotenv()
+
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        return None
+
+    try:
+        import anthropic
+
+        client = anthropic.Anthropic(api_key=api_key)
+
+        message = client.messages.create(
+            model="claude-3-5-haiku-20241022",  # Fastest Anthropic model
+            max_tokens=100,
+            temperature=0.7,
+            messages=[{"role": "user", "content": prompt_text}],
+        )
+
+        return message.content[0].text.strip()
+
+    except Exception:
+        return None
+
+
+def generate_completion_message():
+    """
+    Generate a completion message using Anthropic LLM.
+
+    Returns:
+        str: A natural language completion message, or None if error
+    """
+    engineer_name = os.getenv("ENGINEER_NAME", "").strip()
+
+    if engineer_name:
+        name_instruction = f"Sometimes (about 30% of the time) include the engineer's name '{engineer_name}' in a natural way."
+        examples = f"""Examples of the style: 
+- Standard: "Work complete!", "All done!", "Task finished!", "Ready for your next move!"
+- Personalized: "{engineer_name}, all set!", "Ready for you, {engineer_name}!", "Complete, {engineer_name}!", "{engineer_name}, we're done!" """
+    else:
+        name_instruction = ""
+        examples = """Examples of the style: "Work complete!", "All done!", "Task finished!", "Ready for your next move!" """
+
+    prompt = f"""Generate a short, friendly completion message for when an AI coding assistant finishes a task. 
+
+Requirements:
+- Keep it under 10 words
+- Make it positive and future focused
+- Use natural, conversational language
+- Focus on completion/readiness
+- Do NOT include quotes, formatting, or explanations
+- Return ONLY the completion message text
+{name_instruction}
+
+{examples}
+
+Generate ONE completion message:"""
+
+    response = prompt_llm(prompt)
+
+    # Clean up response - remove quotes and extra formatting
+    if response:
+        response = response.strip().strip('"').strip("'").strip()
+        # Take first line if multiple lines
+        response = response.split("\\n")[0].strip()
+
+    return response
+
+
+def main():
+    """Command line interface for testing."""
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "--completion":
+            message = generate_completion_message()
+            if message:
+                print(message)
+            else:
+                print("Error generating completion message")
+        else:
+            prompt_text = " ".join(sys.argv[1:])
+            response = prompt_llm(prompt_text)
+            if response:
+                print(response)
+            else:
+                print("Error calling Anthropic API")
+    else:
+        print("Usage: ./anth.py 'your prompt here' or ./anth.py --completion")
+
+
+if __name__ == "__main__":
+    main()
+`;
+}
+
+function getElevenlabsMcpScript() {
+  return `#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "python-dotenv",
+# ]
+# ///
+
+import os
+import sys
+import json
+import subprocess
+from pathlib import Path
+from dotenv import load_dotenv
+
+
+def main():
+    """
+    ElevenLabs MCP TTS Script
+    
+    Uses ElevenLabs MCP server for high-quality text-to-speech via Claude Code.
+    Accepts optional text prompt as command-line argument.
+    
+    Usage:
+    - ./elevenlabs_mcp.py                    # Uses default text
+    - ./elevenlabs_mcp.py "Your custom text" # Uses provided text
+    
+    Features:
+    - Integration with Claude Code MCP
+    - Automatic voice selection
+    - High-quality voice synthesis via ElevenLabs API
+    - Optimized for hook usage (quick, reliable)
+    """
+    
+    # Load environment variables
+    load_dotenv()
+    
+    try:
+        print("🎙️  ElevenLabs MCP TTS")
+        print("=" * 25)
+        
+        # Get text from command line argument or use default
+        if len(sys.argv) > 1:
+            text = " ".join(sys.argv[1:])  # Join all arguments as text
+        else:
+            text = "Task completed successfully!"
+        
+        print(f"🎯 Text: {text}")
+        print("🔊 Generating and playing via MCP...")
+        
+        try:
+            # Use Claude Code CLI to invoke ElevenLabs MCP
+            # This assumes the ElevenLabs MCP server is configured in Claude Code
+            claude_cmd = [
+                "claude", "mcp", "call", "ElevenLabs", "text_to_speech",
+                "--text", text,
+                "--voice_name", "Adam",  # Default voice
+                "--model_id", "eleven_turbo_v2_5",  # Fast model
+                "--output_directory", str(Path.home() / "Desktop"),
+                "--speed", "1.0",
+                "--stability", "0.5",
+                "--similarity_boost", "0.75"
+            ]
+            
+            # Try to run the Claude MCP command
+            result = subprocess.run(
+                claude_cmd,
+                capture_output=True,
+                text=True,
+                timeout=15  # 15-second timeout for TTS generation
+            )
+            
+            if result.returncode == 0:
+                print("✅ TTS generated and played via MCP!")
+                
+                # Try to play the generated audio file
+                # Look for recently created audio files on Desktop
+                desktop = Path.home() / "Desktop"
+                audio_files = list(desktop.glob("*.mp3"))
+                
+                if audio_files:
+                    # Find the most recent audio file
+                    latest_audio = max(audio_files, key=lambda f: f.stat().st_mtime)
+                    
+                    # Try to play with system default audio player
+                    if sys.platform == "darwin":  # macOS
+                        subprocess.run(["afplay", str(latest_audio)], capture_output=True)
+                    elif sys.platform == "linux":  # Linux
+                        subprocess.run(["aplay", str(latest_audio)], capture_output=True)
+                    elif sys.platform == "win32":  # Windows
+                        subprocess.run(["start", str(latest_audio)], shell=True, capture_output=True)
+                    
+                    print("🎵 Audio playback attempted")
+                else:
+                    print("⚠️  Audio file not found on Desktop")
+            else:
+                print(f"❌ MCP Error: {result.stderr}")
+                # Fall back to simple notification
+                print("🔔 TTS via MCP failed - task completion noted")
+                
+        except subprocess.TimeoutExpired:
+            print("⏰ MCP TTS timed out - continuing...")
+        except FileNotFoundError:
+            print("❌ Claude CLI not found - MCP TTS unavailable")
+        except Exception as e:
+            print(f"❌ MCP Error: {e}")
+        
+    except Exception as e:
+        print(f"❌ Unexpected error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+`;
+}
+
+function getOpenaiTtsScript() {
+  return `#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "openai",
+#     "python-dotenv",
+# ]
+# ///
+
+import os
+import sys
+import asyncio
+from pathlib import Path
+from dotenv import load_dotenv
+
+
+async def main():
+    """
+    OpenAI TTS Script
+
+    Uses OpenAI's TTS model for high-quality text-to-speech.
+    Accepts optional text prompt as command-line argument.
+
+    Usage:
+    - ./openai_tts.py                    # Uses default text
+    - ./openai_tts.py "Your custom text" # Uses provided text
+
+    Features:
+    - OpenAI TTS-1 model (fast and reliable)
+    - Nova voice (engaging and warm)
+    - Direct audio streaming and playback
+    - Optimized for hook usage
+    """
+
+    # Load environment variables
+    load_dotenv()
+
+    # Get API key from environment
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        print("❌ Error: OPENAI_API_KEY not found in environment variables")
+        sys.exit(1)
+
+    try:
+        from openai import AsyncOpenAI
+
+        # Initialize OpenAI client
+        openai = AsyncOpenAI(api_key=api_key)
+
+        print("🎙️  OpenAI TTS")
+        print("=" * 15)
+
+        # Get text from command line argument or use default
+        if len(sys.argv) > 1:
+            text = " ".join(sys.argv[1:])  # Join all arguments as text
+        else:
+            text = "Task completed successfully!"
+
+        print(f"🎯 Text: {text}")
+        print("🔊 Generating audio...")
+
+        try:
+            # Generate audio using OpenAI TTS
+            response = await openai.audio.speech.create(
+                model="tts-1",
+                voice="nova",
+                input=text,
+                response_format="mp3",
+            )
+            
+            # Save to temporary file
+            audio_file = Path.home() / "Desktop" / "tts_completion.mp3"
+            with open(audio_file, "wb") as f:
+                async for chunk in response.iter_bytes():
+                    f.write(chunk)
+            
+            print("🎵 Playing audio...")
+            
+            # Play the audio file
+            import subprocess
+            if sys.platform == "darwin":  # macOS
+                subprocess.run(["afplay", str(audio_file)], capture_output=True)
+            elif sys.platform == "linux":  # Linux
+                subprocess.run(["aplay", str(audio_file)], capture_output=True)
+            elif sys.platform == "win32":  # Windows
+                subprocess.run(["start", str(audio_file)], shell=True, capture_output=True)
+
+            print("✅ Playback complete!")
+            
+            # Clean up the temporary file
+            try:
+                audio_file.unlink()
+            except:
+                pass
+
+        except Exception as e:
+            print(f"❌ Error: {e}")
+
+    except ImportError as e:
+        print("❌ Error: Required package not installed")
+        print("This script uses UV to auto-install dependencies.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ Unexpected error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+`;
+}
+
+function getLocalTtsScript() {
+  return `#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "pyttsx3",
+# ]
+# ///
+
+import sys
+import random
+import os
+
+
+def main():
+    """
+    Local TTS Script (pyttsx3)
+    
+    Uses pyttsx3 for offline text-to-speech synthesis.
+    Accepts optional text prompt as command-line argument.
+    
+    Usage:
+    - ./local_tts.py                    # Uses default text
+    - ./local_tts.py "Your custom text" # Uses provided text
+    
+    Features:
+    - Offline TTS (no API key required)
+    - Cross-platform compatibility
+    - Configurable voice settings
+    - Immediate audio playback
+    - Engineer name personalization support
+    """
+    
+    try:
+        import pyttsx3
+        
+        # Initialize TTS engine
+        engine = pyttsx3.init()
+        
+        # Configure engine settings
+        engine.setProperty('rate', 180)    # Speech rate (words per minute)
+        engine.setProperty('volume', 0.9)  # Volume (0.0 to 1.0)
+        
+        print("🎙️  Local TTS")
+        print("=" * 12)
+        
+        # Get text from command line argument or use default
+        if len(sys.argv) > 1:
+            text = " ".join(sys.argv[1:])  # Join all arguments as text
+        else:
+            # Default completion messages with engineer name support
+            engineer_name = os.getenv("ENGINEER_NAME", "").strip()
+            
+            if engineer_name and random.random() < 0.3:  # 30% chance to use name
+                personalized_messages = [
+                    f"{engineer_name}, all set!",
+                    f"Ready for you, {engineer_name}!",
+                    f"Complete, {engineer_name}!",
+                    f"{engineer_name}, we're done!",
+                    f"Task finished, {engineer_name}!"
+                ]
+                text = random.choice(personalized_messages)
+            else:
+                completion_messages = [
+                    "Work complete!",
+                    "All done!",
+                    "Task finished!",
+                    "Job complete!",
+                    "Ready for next task!",
+                    "Ready for your next move!",
+                    "All set!"
+                ]
+                text = random.choice(completion_messages)
+        
+        print(f"🎯 Text: {text}")
+        print("🔊 Speaking...")
+        
+        # Speak the text
+        engine.say(text)
+        engine.runAndWait()
+        
+        print("✅ Playback complete!")
+        
+    except ImportError:
+        print("❌ Error: pyttsx3 package not installed")
+        print("This script uses UV to auto-install dependencies.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+`;
+}

--- a/src/utils/hooks/agent-voice-hook.js
+++ b/src/utils/hooks/agent-voice-hook.js
@@ -1,0 +1,74 @@
+/**
+ * Agent Voice Completion Hook
+ * 
+ * This hook is used by agents to announce task completion via ElevenLabs MCP.
+ * 
+ * Usage in agent.md files:
+ * ```
+ * When you complete a task, use the mcp__ElevenLabs__text_to_speech tool:
+ * 
+ * mcp__ElevenLabs__text_to_speech(
+ *   text: "I've completed the API endpoints. Next, we can add authentication.",
+ *   voice_id: "WejK3H1m7MI9CHnIjW9K",
+ *   output_directory: "."
+ * )
+ * ```
+ */
+
+export function generateAgentVoiceHook(agentName, completionMessage, options = {}) {
+  const defaultVoiceId = 'WejK3H1m7MI9CHnIjW9K'; // Ashlee - Pleasant Expressive
+  const voiceId = options.voiceId || defaultVoiceId;
+  const outputDirectory = options.outputDirectory || process.cwd();
+  
+  // Generate the exact MCP tool invocation format
+  const mcpInvocation = `mcp__ElevenLabs__text_to_speech(
+  text: "${completionMessage}",
+  voice_id: "${voiceId}",
+  output_directory: "${outputDirectory}"
+)`;
+  
+  return mcpInvocation;
+}
+
+// Example voice IDs for different agent personalities
+export const AGENT_VOICES = {
+  'project-planner': 'WejK3H1m7MI9CHnIjW9K',      // Ashlee - Pleasant Expressive
+  'api-developer': 'onwK4e9ZLuTAKqWW03F9',        // Daniel - Professional
+  'frontend-developer': 'EXAVITQu4vr4xnSDxMaL',   // Bella - Creative
+  'tdd-specialist': 'ErXwobaYiN019PkySvjV',       // Antoni - Precise
+  'code-reviewer': '21m00Tcm4TlvDq8ikWAM',        // Rachel - Authoritative
+  'debugger': 'yoZ06aMxZJJ28mfd3POQ',             // Sam - Problem Solver
+  'security-scanner': 'flq6f7yk4E4fJM5XTYuZ',     // Michael - Serious
+  'devops-engineer': '2EiwWnXFnvU5JabPnv8n',      // Clyde - Technical
+  'product-manager': 'ThT5KcBeYPX3keUQqHPh',      // Dorothy - Business
+  'marketing-writer': 'jsCqWAovK2LkecY7zXl4',     // Elli - Engaging
+  'default': 'WejK3H1m7MI9CHnIjW9K'               // Ashlee - Default
+};
+
+/**
+ * Get the appropriate voice ID for an agent
+ */
+export function getAgentVoiceId(agentName) {
+  return AGENT_VOICES[agentName] || AGENT_VOICES.default;
+}
+
+/**
+ * Generate completion message for different agent types
+ */
+export function generateCompletionMessage(agentName, task, result) {
+  const templates = {
+    'project-planner': `I've completed the project planning for ${task}. The roadmap is ready with clear milestones and deliverables.`,
+    'api-developer': `I've finished implementing the ${task}. All endpoints are tested and documented.`,
+    'frontend-developer': `I've completed the ${task}. The interface is responsive and ready for review.`,
+    'tdd-specialist': `I've written comprehensive tests for ${task}. All tests are passing with good coverage.`,
+    'code-reviewer': `I've completed the code review for ${task}. I've identified areas for improvement and security considerations.`,
+    'debugger': `I've resolved the issue with ${task}. The root cause has been fixed and verified.`,
+    'security-scanner': `I've completed the security scan for ${task}. All vulnerabilities have been documented.`,
+    'devops-engineer': `I've set up the ${task}. The pipeline is configured and ready to use.`,
+    'product-manager': `I've completed the ${task}. User stories and requirements are documented.`,
+    'marketing-writer': `I've written the ${task}. The content is ready for publication.`,
+    'default': `I've completed ${task}. Everything is ready for the next step.`
+  };
+  
+  return templates[agentName] || templates.default;
+}

--- a/src/utils/hooks/runner.js
+++ b/src/utils/hooks/runner.js
@@ -1,0 +1,234 @@
+/**
+ * Hooks System Integration
+ * 
+ * Integrates sub-agents with Claude Code hooks system for event-driven orchestration.
+ */
+
+import { spawn } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import chalk from 'chalk';
+
+/**
+ * Detect if we're running inside Claude Code (MCP environment)
+ */
+export function isClaudeCodeEnvironment() {
+  // Check for MCP availability or Claude Code environment indicators
+  const mcpIndicators = [
+    process.env.MCP_SERVER_RUNNING,
+    process.env.CLAUDE_CODE_SESSION,
+    process.env.ANTHROPIC_MCP_CLIENT,
+    // Check if specific MCP tools are available by looking for process args
+    process.argv.some(arg => arg.includes('claude') || arg.includes('mcp'))
+  ];
+  
+  return mcpIndicators.some(indicator => indicator);
+}
+
+/**
+ * Load hooks configuration from .claude/settings.json
+ */
+export function loadHooksConfig(projectPath = process.cwd()) {
+  const settingsPath = join(projectPath, '.claude', 'settings.json');
+  
+  if (!existsSync(settingsPath)) {
+    return null;
+  }
+  
+  try {
+    const content = readFileSync(settingsPath, 'utf-8');
+    const settings = JSON.parse(content);
+    return settings.hooks || null;
+  } catch (error) {
+    console.error(chalk.yellow('Warning: Failed to load hooks config:'), error.message);
+    return null;
+  }
+}
+
+/**
+ * Execute hooks for a specific event type
+ */
+export async function executeHooks(eventType, data, options = {}) {
+  const { projectPath = process.cwd(), verbose = false } = options;
+  
+  // Only execute hooks if we're in Claude Code environment
+  if (!isClaudeCodeEnvironment()) {
+    if (verbose) {
+      console.log(chalk.gray(`Skipping hooks (not in Claude Code environment)`));
+    }
+    return;
+  }
+  
+  const hooksConfig = loadHooksConfig(projectPath);
+  if (!hooksConfig || !hooksConfig[eventType]) {
+    if (verbose) {
+      console.log(chalk.gray(`No hooks configured for event: ${eventType}`));
+    }
+    return;
+  }
+  
+  const eventHooks = hooksConfig[eventType];
+  
+  for (const hookGroup of eventHooks) {
+    const { matcher = '', hooks = [] } = hookGroup;
+    
+    // Simple matcher support (empty matcher matches all)
+    if (matcher && !matchesFilter(data, matcher)) {
+      continue;
+    }
+    
+    for (const hook of hooks) {
+      if (hook.type === 'command') {
+        try {
+          await executeCommandHook(hook.command, data, { projectPath, verbose });
+        } catch (error) {
+          console.error(chalk.red(`Hook execution failed: ${hook.command}`), error.message);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Execute a command hook with data passed via stdin
+ */
+async function executeCommandHook(command, data, options = {}) {
+  const { projectPath, verbose } = options;
+  
+  return new Promise((resolve, reject) => {
+    if (verbose) {
+      console.log(chalk.gray(`Executing hook: ${command}`));
+    }
+    
+    const child = spawn('sh', ['-c', command], {
+      cwd: projectPath,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    
+    let stdout = '';
+    let stderr = '';
+    
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    
+    child.on('close', (code) => {
+      if (code === 0) {
+        if (verbose && stdout) {
+          console.log(chalk.gray('Hook output:'), stdout.trim());
+        }
+        resolve({ stdout, stderr, code });
+      } else {
+        reject(new Error(`Hook exited with code ${code}: ${stderr}`));
+      }
+    });
+    
+    child.on('error', (error) => {
+      reject(error);
+    });
+    
+    // Send data to hook via stdin as JSON
+    if (data) {
+      child.stdin.write(JSON.stringify(data, null, 2));
+    }
+    child.stdin.end();
+  });
+}
+
+/**
+ * Simple matcher function
+ */
+function matchesFilter(data, matcher) {
+  if (!matcher) return true;
+  
+  // For now, just support simple string matching
+  const dataStr = JSON.stringify(data).toLowerCase();
+  return dataStr.includes(matcher.toLowerCase());
+}
+
+/**
+ * Emit SubagentStop event when agent completes
+ */
+export async function emitSubagentStop(agentData, options = {}) {
+  const eventData = {
+    event: 'SubagentStop',
+    timestamp: new Date().toISOString(),
+    agent: {
+      name: agentData.name,
+      task: agentData.task,
+      status: agentData.status,
+      duration: agentData.duration,
+      result: agentData.result
+    },
+    context: {
+      executionId: agentData.executionId,
+      targetFile: agentData.targetFile,
+      handoffs: agentData.handoffs || []
+    }
+  };
+  
+  await executeHooks('SubagentStop', eventData, options);
+}
+
+/**
+ * Emit Stop event when session completes
+ */
+export async function emitStop(sessionData, options = {}) {
+  const eventData = {
+    event: 'Stop',
+    timestamp: new Date().toISOString(),
+    session: {
+      totalAgents: sessionData.totalAgents,
+      completedTasks: sessionData.completedTasks,
+      duration: sessionData.duration
+    }
+  };
+  
+  await executeHooks('Stop', eventData, options);
+}
+
+/**
+ * Create a default .claude/settings.json template
+ */
+export function createDefaultHooksConfig() {
+  return {
+    hooks: {
+      SubagentStop: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command',
+              command: 'node .claude/hooks/subagent-completion.js'
+            }
+          ]
+        }
+      ],
+      Stop: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command',
+              command: 'node .claude/hooks/session-complete.js'
+            }
+          ]
+        }
+      ],
+      UserPromptSubmit: [
+        {
+          hooks: [
+            {
+              type: 'command',
+              command: 'node .claude/hooks/orchestrator.js'
+            }
+          ]
+        }
+      ]
+    }
+  };
+}

--- a/src/utils/hooks/task-integration.js
+++ b/src/utils/hooks/task-integration.js
@@ -1,0 +1,258 @@
+/**
+ * Task Tool Integration
+ * 
+ * Detects Task tool usage and integrates with hooks system for Claude Code environment.
+ */
+
+import { emitSubagentStop } from './runner.js';
+import chalk from 'chalk';
+
+/**
+ * Task completion tracker for Claude Code integration
+ */
+class TaskTracker {
+  constructor() {
+    this.activeTasks = new Map();
+    this.completedTasks = [];
+  }
+
+  /**
+   * Register a new task execution
+   */
+  registerTask(taskId, agentName, taskDescription, options = {}) {
+    const taskData = {
+      id: taskId,
+      agent: agentName,
+      task: taskDescription,
+      startTime: Date.now(),
+      status: 'running',
+      targetFile: options.targetFile,
+      executionId: options.executionId
+    };
+
+    this.activeTasks.set(taskId, taskData);
+    
+    if (options.verbose) {
+      console.log(chalk.gray(`📋 Task registered: ${agentName} - ${taskDescription}`));
+    }
+
+    return taskData;
+  }
+
+  /**
+   * Mark task as completed and emit hooks
+   */
+  async completeTask(taskId, result = {}, options = {}) {
+    const taskData = this.activeTasks.get(taskId);
+    if (!taskData) {
+      console.warn(chalk.yellow(`Warning: Task ${taskId} not found in tracker`));
+      return;
+    }
+
+    // Update task data
+    taskData.status = 'completed';
+    taskData.endTime = Date.now();
+    taskData.duration = taskData.endTime - taskData.startTime;
+    taskData.result = result;
+
+    // Move to completed tasks
+    this.activeTasks.delete(taskId);
+    this.completedTasks.push(taskData);
+
+    if (options.verbose) {
+      console.log(chalk.green(`✅ Task completed: ${taskData.agent} (${taskData.duration}ms)`));
+    }
+
+    // Emit SubagentStop hook for Claude Code
+    try {
+      await emitSubagentStop({
+        name: taskData.agent,
+        task: taskData.task,
+        status: taskData.status,
+        duration: taskData.duration,
+        result: taskData.result,
+        executionId: taskData.executionId,
+        targetFile: taskData.targetFile,
+        handoffs: result.handoffs || []
+      }, options);
+    } catch (error) {
+      console.error(chalk.red('Failed to emit SubagentStop hook:'), error.message);
+    }
+
+    return taskData;
+  }
+
+  /**
+   * Mark task as failed
+   */
+  async failTask(taskId, error, options = {}) {
+    const taskData = this.activeTasks.get(taskId);
+    if (!taskData) {
+      console.warn(chalk.yellow(`Warning: Task ${taskId} not found in tracker`));
+      return;
+    }
+
+    // Update task data
+    taskData.status = 'failed';
+    taskData.endTime = Date.now();
+    taskData.duration = taskData.endTime - taskData.startTime;
+    taskData.error = error;
+
+    // Move to completed tasks
+    this.activeTasks.delete(taskId);
+    this.completedTasks.push(taskData);
+
+    if (options.verbose) {
+      console.log(chalk.red(`❌ Task failed: ${taskData.agent} - ${error.message}`));
+    }
+
+    // Emit SubagentStop hook with failure status
+    try {
+      await emitSubagentStop({
+        name: taskData.agent,
+        task: taskData.task,
+        status: taskData.status,
+        duration: taskData.duration,
+        error: error.message,
+        executionId: taskData.executionId,
+        targetFile: taskData.targetFile
+      }, options);
+    } catch (hookError) {
+      console.error(chalk.red('Failed to emit SubagentStop hook:'), hookError.message);
+    }
+
+    return taskData;
+  }
+
+  /**
+   * Get all active tasks
+   */
+  getActiveTasks() {
+    return Array.from(this.activeTasks.values());
+  }
+
+  /**
+   * Get completed tasks
+   */
+  getCompletedTasks() {
+    return this.completedTasks;
+  }
+
+  /**
+   * Get task by ID
+   */
+  getTask(taskId) {
+    return this.activeTasks.get(taskId) || 
+           this.completedTasks.find(task => task.id === taskId);
+  }
+
+  /**
+   * Clear completed tasks (cleanup)
+   */
+  clearCompleted() {
+    this.completedTasks = [];
+  }
+}
+
+// Global task tracker instance
+const globalTaskTracker = new TaskTracker();
+
+/**
+ * Create a new task execution context
+ */
+export function createTaskExecution(agentName, taskDescription, options = {}) {
+  const taskId = `task_${agentName}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  
+  return globalTaskTracker.registerTask(taskId, agentName, taskDescription, {
+    ...options,
+    executionId: options.executionId || `exec_${Date.now()}`
+  });
+}
+
+/**
+ * Complete a task execution
+ */
+export async function completeTaskExecution(taskId, result = {}, options = {}) {
+  return await globalTaskTracker.completeTask(taskId, result, options);
+}
+
+/**
+ * Fail a task execution
+ */
+export async function failTaskExecution(taskId, error, options = {}) {
+  return await globalTaskTracker.failTask(taskId, error, options);
+}
+
+/**
+ * Get the global task tracker instance
+ */
+export function getTaskTracker() {
+  return globalTaskTracker;
+}
+
+/**
+ * Middleware to wrap agent execution with task tracking
+ */
+export function withTaskTracking(agentName, taskDescription, executionFn, options = {}) {
+  return async (...args) => {
+    const taskData = createTaskExecution(agentName, taskDescription, options);
+    
+    try {
+      const result = await executionFn(...args, taskData);
+      await completeTaskExecution(taskData.id, result, options);
+      return result;
+    } catch (error) {
+      await failTaskExecution(taskData.id, error, options);
+      throw error;
+    }
+  };
+}
+
+/**
+ * Claude Code Task tool detection patterns
+ * These patterns help identify when agents are being executed via Task tool
+ */
+export const TASK_TOOL_PATTERNS = {
+  // Common Task tool invocation patterns
+  TASK_INVOCATION: /Task\s*\(\s*["']([^"']+)["']\s*\)/g,
+  AGENT_MENTION: /(?:agent|Agent):\s*([a-zA-Z-]+)/g,
+  SLASH_COMMAND: /\/([a-zA-Z-]+)(?:\s|$)/g,
+  
+  // Extract agent name from task string
+  extractAgentName(taskString) {
+    // Look for patterns like "api-developer: implement endpoints"
+    const agentMatch = taskString.match(/^([a-zA-Z-]+):\s*/);
+    if (agentMatch) {
+      return agentMatch[1];
+    }
+    
+    // Look for slash commands like "/debug" or "/review"
+    const slashMatch = taskString.match(/^\/([a-zA-Z-]+)/);
+    if (slashMatch) {
+      const command = slashMatch[1];
+      // Map common slash commands to agent names
+      const commandMap = {
+        'review': 'code-reviewer',
+        'test': 'test-runner',
+        'debug': 'debugger',
+        'refactor': 'refactor',
+        'document': 'doc-writer',
+        'security-scan': 'security-scanner',
+        'ui': 'shadcn-ui-builder',
+        'shadcn': 'shadcn-ui-builder'
+      };
+      return commandMap[command] || command;
+    }
+    
+    return null;
+  },
+  
+  // Extract task description
+  extractTaskDescription(taskString) {
+    // Remove agent prefix if present
+    let description = taskString.replace(/^([a-zA-Z-]+):\s*/, '');
+    // Remove slash command if present
+    description = description.replace(/^\/[a-zA-Z-]+\s*/, '');
+    return description.trim();
+  }
+};

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -5,10 +5,12 @@ import { existsSync, mkdirSync } from 'fs';
 export const CLAUDE_USER_DIR = join(homedir(), '.claude');
 export const CLAUDE_USER_AGENTS_DIR = join(CLAUDE_USER_DIR, 'agents');
 export const CLAUDE_USER_COMMANDS_DIR = join(CLAUDE_USER_DIR, 'commands');
+export const CLAUDE_USER_HOOKS_DIR = join(CLAUDE_USER_DIR, 'hooks');
 
 export const CLAUDE_PROJECT_DIR = join(process.cwd(), '.claude');
 export const CLAUDE_PROJECT_AGENTS_DIR = join(CLAUDE_PROJECT_DIR, 'agents');
 export const CLAUDE_PROJECT_COMMANDS_DIR = join(CLAUDE_PROJECT_DIR, 'commands');
+export const CLAUDE_PROJECT_HOOKS_DIR = join(CLAUDE_PROJECT_DIR, 'hooks');
 
 export const AGENTS_CONFIG_FILE = '.claude-agents.json';
 
@@ -20,6 +22,10 @@ export function getCommandsDir(isProject = false) {
   return isProject ? CLAUDE_PROJECT_COMMANDS_DIR : CLAUDE_USER_COMMANDS_DIR;
 }
 
+export function getHooksDir(isProject = false) {
+  return isProject ? CLAUDE_PROJECT_HOOKS_DIR : CLAUDE_USER_HOOKS_DIR;
+}
+
 export function getConfigPath(isProject = false) {
   const baseDir = isProject ? process.cwd() : homedir();
   return join(baseDir, AGENTS_CONFIG_FILE);
@@ -29,7 +35,8 @@ export function ensureDirectories() {
   const dirs = [
     CLAUDE_USER_DIR,
     CLAUDE_USER_AGENTS_DIR,
-    CLAUDE_USER_COMMANDS_DIR
+    CLAUDE_USER_COMMANDS_DIR,
+    CLAUDE_USER_HOOKS_DIR
   ];
   
   dirs.forEach(dir => {
@@ -43,7 +50,8 @@ export function ensureProjectDirectories() {
   const dirs = [
     CLAUDE_PROJECT_DIR,
     CLAUDE_PROJECT_AGENTS_DIR,
-    CLAUDE_PROJECT_COMMANDS_DIR
+    CLAUDE_PROJECT_COMMANDS_DIR,
+    CLAUDE_PROJECT_HOOKS_DIR
   ];
   
   dirs.forEach(dir => {

--- a/src/utils/tts/index.js
+++ b/src/utils/tts/index.js
@@ -1,0 +1,146 @@
+import MCPProvider from './providers/mcp.js';
+import OpenAIProvider from './providers/openai.js';
+import LocalProvider from './providers/local.js';
+import { getVoiceConfig } from '../config.js';
+
+class TTSManager {
+  constructor() {
+    this.providers = {
+      mcp: new MCPProvider(), // Uses ElevenLabs MCP server
+      openai: new OpenAIProvider(),
+      local: new LocalProvider()
+    };
+  }
+
+  async speak(text, options = {}) {
+    const config = getVoiceConfig();
+    
+    if (!config.enabled && !options.force) {
+      return { success: false, reason: 'Voice disabled' };
+    }
+
+    const provider = this.selectProvider(config, options);
+    
+    if (!provider) {
+      return { success: false, reason: 'No available TTS provider' };
+    }
+
+    try {
+      return await provider.speak(text, options);
+    } catch (error) {
+      // Try fallback providers
+      const fallbacks = this.getFallbackProviders(provider.name);
+      
+      for (const fallback of fallbacks) {
+        try {
+          return await fallback.speak(text, options);
+        } catch (fallbackError) {
+          continue;
+        }
+      }
+      
+      return { success: false, reason: error.message };
+    }
+  }
+
+  selectProvider(config, options) {
+    // Check if specific provider requested
+    if (options.provider) {
+      const provider = this.providers[options.provider];
+      if (provider && provider.isAvailable()) {
+        return provider;
+      }
+    }
+
+    // Use configured provider preference
+    if (config.provider && config.provider !== 'auto') {
+      const provider = this.providers[config.provider];
+      if (provider && provider.isAvailable()) {
+        return provider;
+      }
+    }
+
+    // Auto-select based on priority
+    const priority = ['mcp', 'openai', 'local'];
+    
+    for (const name of priority) {
+      const provider = this.providers[name];
+      if (provider && provider.isAvailable()) {
+        return provider;
+      }
+    }
+
+    return null;
+  }
+
+  getFallbackProviders(excludeName) {
+    const priority = ['mcp', 'openai', 'local'];
+    return priority
+      .filter(name => name !== excludeName)
+      .map(name => this.providers[name])
+      .filter(provider => provider && provider.isAvailable());
+  }
+
+  async testVoice(text = 'Claude agents voice test successful!') {
+    const config = getVoiceConfig();
+    const results = {};
+
+    for (const [name, provider] of Object.entries(this.providers)) {
+      if (provider.isAvailable()) {
+        try {
+          const result = await provider.speak(text, { test: true });
+          results[name] = { available: true, success: result.success };
+        } catch (error) {
+          results[name] = { available: true, success: false, error: error.message };
+        }
+      } else {
+        results[name] = { available: false };
+      }
+    }
+
+    return results;
+  }
+}
+
+// Singleton instance
+let ttsManager;
+
+function getTTS() {
+  if (!ttsManager) {
+    ttsManager = new TTSManager();
+  }
+  return ttsManager;
+}
+
+// Convenience functions
+async function speak(text, options = {}) {
+  return getTTS().speak(text, options);
+}
+
+async function announceAgentComplete(agentName, taskDescription) {
+  const messages = [
+    `${agentName} agent has completed its task`,
+    `${agentName} finished: ${taskDescription}`,
+    `Task complete by ${agentName}`,
+    `${agentName} agent done`
+  ];
+  
+  const message = messages[Math.floor(Math.random() * messages.length)];
+  return speak(message);
+}
+
+async function announceError(error, context) {
+  const message = context 
+    ? `Error in ${context}: ${error}`
+    : `Error encountered: ${error}`;
+  
+  return speak(message, { priority: 'high' });
+}
+
+export {
+  getTTS,
+  speak,
+  announceAgentComplete,
+  announceError,
+  TTSManager
+};

--- a/src/utils/tts/providers/local.js
+++ b/src/utils/tts/providers/local.js
@@ -1,0 +1,105 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import os from 'os';
+const execAsync = promisify(exec);
+
+class LocalProvider {
+  constructor() {
+    this.name = 'local';
+    this.platform = os.platform();
+  }
+
+  isAvailable() {
+    // Always available as fallback
+    return true;
+  }
+
+  async speak(text, options = {}) {
+    try {
+      const command = await this.getCommand(text);
+      
+      if (!command) {
+        throw new Error('No local TTS command available for this platform');
+      }
+
+      await execAsync(command);
+
+      return {
+        success: true,
+        provider: 'local',
+        method: this.getMethod()
+      };
+    } catch (error) {
+      throw new Error(`Local TTS failed: ${error.message}`);
+    }
+  }
+
+  async getCommand(text) {
+    // Escape quotes and special characters for shell
+    const escapedText = text.replace(/'/g, "'\"'\"'").replace(/\$/g, '\\$');
+
+    if (this.platform === 'darwin') {
+      // macOS - use 'say' command
+      const voice = await this.getMacVoice();
+      return `say -v "${voice}" '${escapedText}'`;
+    } else if (this.platform === 'linux') {
+      // Linux - try espeak-ng, then espeak, then festival
+      const commands = [
+        `espeak-ng '${escapedText}'`,
+        `espeak '${escapedText}'`,
+        `echo '${escapedText}' | festival --tts`
+      ];
+
+      for (const cmd of commands) {
+        try {
+          const binary = cmd.split(' ')[0];
+          await execAsync(`which ${binary}`);
+          return cmd;
+        } catch (e) {
+          continue;
+        }
+      }
+      
+      throw new Error('No TTS tool found. Install espeak-ng or espeak.');
+    } else if (this.platform === 'win32') {
+      // Windows - use PowerShell's speech synthesis
+      const psCommand = `Add-Type -AssemblyName System.speech; $speak = New-Object System.Speech.Synthesis.SpeechSynthesizer; $speak.Speak('${escapedText}')`;
+      return `powershell -Command "${psCommand}"`;
+    }
+
+    return null;
+  }
+
+  async getMacVoice() {
+    try {
+      // Get list of available voices
+      const { stdout } = await execAsync('say -v ?');
+      const voices = stdout.split('\n')
+        .filter(line => line.includes('en_'))
+        .map(line => line.split(/\s+/)[0]);
+
+      // Prefer these voices in order
+      const preferred = ['Samantha', 'Alex', 'Victoria', 'Fred'];
+      
+      for (const voice of preferred) {
+        if (voices.includes(voice)) {
+          return voice;
+        }
+      }
+
+      // Default to first English voice or system default
+      return voices[0] || 'Alex';
+    } catch (error) {
+      return 'Alex'; // Default macOS voice
+    }
+  }
+
+  getMethod() {
+    if (this.platform === 'darwin') return 'say';
+    if (this.platform === 'linux') return 'espeak/festival';
+    if (this.platform === 'win32') return 'powershell';
+    return 'unknown';
+  }
+}
+
+export default LocalProvider;

--- a/src/utils/tts/providers/mcp.js
+++ b/src/utils/tts/providers/mcp.js
@@ -1,0 +1,89 @@
+import { execSync } from 'child_process';
+
+/**
+ * MCP Provider for TTS using ElevenLabs MCP Server
+ * Requires the ElevenLabs MCP server to be configured in Claude Code
+ * 
+ * Setup in Claude Code settings.json:
+ * {
+ *   "mcpServers": {
+ *     "ElevenLabs": {
+ *       "command": "uvx",
+ *       "args": ["elevenlabs-mcp"],
+ *       "env": {
+ *         "ELEVENLABS_API_KEY": "your-api-key"
+ *       }
+ *     }
+ *   }
+ * }
+ * 
+ * The MCP tool will be available as mcp__ElevenLabs__text_to_speech
+ */
+class MCPProvider {
+  constructor() {
+    this.name = 'mcp';
+    this.mcpToolName = 'mcp__ElevenLabs__text_to_speech';
+  }
+
+  isAvailable() {
+    try {
+      // Check if Claude Code is running and MCP is available
+      // This is a simplified check - in production, we'd verify MCP connection
+      return process.env.CLAUDE_PROJECT_DIR !== undefined;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async speak(text, options = {}) {
+    if (!this.isAvailable()) {
+      throw new Error('MCP provider not available - ElevenLabs MCP server not connected');
+    }
+
+    try {
+      // In the actual Claude Code environment, agents would use the Task tool
+      // to invoke the MCP tool. For the CLI tool, we'll need a different approach.
+      
+      // For CLI usage outside Claude Code, we can:
+      // 1. Fall back to direct API calls
+      // 2. Or signal that this requires Claude Code environment
+      
+      if (options.inClaudeCode) {
+        // This would be called from within a Claude Code agent
+        // The agent would use: Task("Use mcp__elevenlabs__text_to_speech tool")
+        return {
+          success: true,
+          provider: 'mcp-elevenlabs',
+          message: 'Voice played via ElevenLabs MCP'
+        };
+      } else {
+        // For CLI usage, we need a different approach
+        throw new Error('MCP provider requires Claude Code environment with ElevenLabs MCP server');
+      }
+    } catch (error) {
+      throw new Error(`MCP TTS failed: ${error.message}`);
+    }
+  }
+
+  /**
+   * Generate the command for Claude Code agents to use
+   * This helps agents know how to invoke the MCP tool
+   */
+  getClaudeCodeCommand(text, options = {}) {
+    // Default voice_id for agent announcements
+    const voiceId = options.voiceId || 'WejK3H1m7MI9CHnIjW9K'; // Ashlee voice
+    const outputDir = options.outputDirectory || process.cwd();
+    
+    // Return the exact format for MCP tool invocation
+    return {
+      tool: this.mcpToolName,
+      parameters: {
+        text: text,
+        voice_id: voiceId,
+        output_directory: outputDir
+      }
+    };
+  }
+}
+
+export default MCPProvider;

--- a/src/utils/tts/providers/openai.js
+++ b/src/utils/tts/providers/openai.js
@@ -1,0 +1,130 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+const execAsync = promisify(exec);
+
+class OpenAIProvider {
+  constructor() {
+    this.name = 'openai';
+    this.apiKey = process.env.OPENAI_API_KEY;
+    this.baseUrl = 'https://api.openai.com/v1/audio/speech';
+    this.defaultVoice = 'nova'; // alloy, echo, fable, onyx, nova, shimmer
+    this.defaultModel = 'tts-1'; // tts-1 or tts-1-hd
+  }
+
+  isAvailable() {
+    return !!this.apiKey;
+  }
+
+  async speak(text, options = {}) {
+    if (!this.isAvailable()) {
+      throw new Error('OpenAI API key not configured');
+    }
+
+    const voice = options.voice || this.defaultVoice;
+    const model = options.model || this.defaultModel;
+    
+    try {
+      // Create temp file for audio
+      const tempFile = path.join(os.tmpdir(), `claude-agents-tts-${Date.now()}.mp3`);
+      
+      // Make API request using fetch (Node 18+) or fall back to curl
+      const response = await this.fetchAudio(text, voice, model);
+      
+      if (!response.ok) {
+        throw new Error(`OpenAI TTS API error: ${response.status}`);
+      }
+
+      // Save audio to temp file
+      const buffer = await response.arrayBuffer();
+      fs.writeFileSync(tempFile, Buffer.from(buffer));
+
+      // Play the audio file
+      await this.playAudio(tempFile);
+
+      // Clean up
+      fs.unlinkSync(tempFile);
+
+      return {
+        success: true,
+        provider: 'openai',
+        voice,
+        model
+      };
+    } catch (error) {
+      throw new Error(`OpenAI TTS failed: ${error.message}`);
+    }
+  }
+
+  async fetchAudio(text, voice, model) {
+    // Try native fetch first (Node 18+)
+    if (global.fetch) {
+      return fetch(this.baseUrl, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          model,
+          input: text,
+          voice,
+          response_format: 'mp3'
+        })
+      });
+    }
+
+    // Fall back to curl for older Node versions
+    const curlCommand = `curl -s -X POST ${this.baseUrl} \
+      -H "Authorization: Bearer ${this.apiKey}" \
+      -H "Content-Type: application/json" \
+      -d '${JSON.stringify({ model, input: text, voice })}' \
+      --output -`;
+
+    const { stdout, stderr } = await execAsync(curlCommand);
+    
+    if (stderr) {
+      throw new Error(stderr);
+    }
+
+    // Mock response object for compatibility
+    return {
+      ok: true,
+      arrayBuffer: async () => Buffer.from(stdout, 'binary')
+    };
+  }
+
+  async playAudio(filePath) {
+    const platform = os.platform();
+    let command;
+
+    if (platform === 'darwin') {
+      command = `afplay "${filePath}"`;
+    } else if (platform === 'linux') {
+      // Try multiple players in order of preference
+      const players = ['mpg123', 'play', 'aplay', 'ffplay'];
+      for (const player of players) {
+        try {
+          await execAsync(`which ${player}`);
+          command = `${player} "${filePath}"`;
+          break;
+        } catch (e) {
+          continue;
+        }
+      }
+      if (!command) {
+        throw new Error('No audio player found. Install mpg123 or sox.');
+      }
+    } else if (platform === 'win32') {
+      command = `powershell -c "(New-Object Media.SoundPlayer '${filePath}').PlaySync()"`;
+    } else {
+      throw new Error(`Unsupported platform: ${platform}`);
+    }
+
+    await execAsync(command);
+  }
+}
+
+export default OpenAIProvider;

--- a/src/utils/voice/agent-announcements.js
+++ b/src/utils/voice/agent-announcements.js
@@ -1,0 +1,152 @@
+/**
+ * Agent Voice Announcements via ElevenLabs MCP
+ * 
+ * This module handles voice announcements for agent completions
+ * using the ElevenLabs MCP server in Claude Code.
+ */
+
+import { getVoiceConfig } from '../config.js';
+
+/**
+ * Generate the MCP tool invocation for agent voice announcements
+ * 
+ * @param {string} agentName - Name of the agent
+ * @param {string} message - Completion message
+ * @param {Object} options - Additional options
+ * @returns {string} MCP tool invocation string
+ */
+export function generateMCPVoiceCommand(agentName, message, options = {}) {
+  const config = getVoiceConfig();
+  
+  // Use agent-specific voice or default
+  const voiceId = options.voiceId || getAgentVoiceId(agentName);
+  const outputDirectory = options.outputDirectory || process.cwd();
+  
+  // Format for Claude Code MCP tool invocation
+  return `mcp__ElevenLabs__text_to_speech(
+  text: "${message}",
+  voice_id: "${voiceId}",
+  output_directory: "${outputDirectory}"
+)`;
+}
+
+/**
+ * Agent-specific voice IDs matching ElevenLabs voices
+ */
+export const AGENT_VOICES = {
+  // Professional voices
+  'project-planner': 'onwK4e9ZLuTAKqWW03F9',        // Daniel - Clear & Professional
+  'api-developer': '21m00Tcm4TlvDq8ikWAM',          // Rachel - Authoritative
+  'devops-engineer': '2EiwWnXFnvU5JabPnv8n',        // Clyde - Technical
+  
+  // Creative voices
+  'frontend-developer': 'EXAVITQu4vr4xnSDxMaL',     // Bella - Creative & Warm
+  'shadcn-ui-builder': 'jsCqWAovK2LkecY7zXl4',      // Elli - Engaging
+  'marketing-writer': 'ThT5KcBeYPX3keUQqHPh',       // Dorothy - Business
+  
+  // Analytical voices
+  'code-reviewer': 'ErXwobaYiN019PkySvjV',          // Antoni - Precise
+  'tdd-specialist': 'yoZ06aMxZJJ28mfd3POQ',         // Sam - Problem Solver
+  'debugger': 'flq6f7yk4E4fJM5XTYuZ',               // Michael - Serious
+  'security-scanner': 'TX3LPaxmHKxFdv7VOQHJ',       // Liam - Stoic
+  
+  // Documentation voices
+  'doc-writer': 'z9fAnlkpzviPz146aGWa',             // Glinda - Witch
+  'api-documenter': 'XB0fDUnXU5powFXDhCwa',         // Charlotte - Swedish
+  
+  // Support voices
+  'test-runner': 'cgSgspJ2msm6clMCkdW9',            // Default voice
+  'refactor': 'GBv7mTt0atIp3Br8iCZE',               // Thomas - Calm
+  'product-manager': 'nPczCjzI2devNBz1zQrb',        // Brian - Trustworthy
+  
+  // Meta
+  'meta-agent': 'zrHiDhphv9ZnVXBqCLjz',             // Mimi - Childish (playful for creation)
+  
+  // Default fallback
+  'default': 'cgSgspJ2msm6clMCkdW9'                 // ElevenLabs default
+};
+
+/**
+ * Get the appropriate voice ID for an agent
+ */
+export function getAgentVoiceId(agentName) {
+  return AGENT_VOICES[agentName] || AGENT_VOICES.default;
+}
+
+/**
+ * Generate contextual completion messages for agents
+ */
+export function generateCompletionMessage(agentName, task, result = {}) {
+  const templates = {
+    'project-planner': `I've completed the project planning for ${task}. The roadmap includes ${result.milestones || 'key milestones'} and clear deliverables.`,
+    'api-developer': `I've finished implementing ${task}. All ${result.endpoints || 'endpoints'} are tested and documented.`,
+    'frontend-developer': `I've completed ${task}. The interface is ${result.responsive ? 'responsive and' : ''} ready for review.`,
+    'tdd-specialist': `I've written comprehensive tests for ${task}. ${result.coverage ? `Coverage is at ${result.coverage}%` : 'All tests are passing'}.`,
+    'code-reviewer': `I've completed the code review for ${task}. ${result.issues ? `Found ${result.issues} areas for improvement` : 'The code looks good'}.`,
+    'debugger': `I've resolved the issue with ${task}. ${result.rootCause ? `Root cause: ${result.rootCause}` : 'The bug has been fixed'}.`,
+    'security-scanner': `Security scan complete for ${task}. ${result.vulnerabilities ? `Found ${result.vulnerabilities} items to address` : 'No critical issues found'}.`,
+    'devops-engineer': `I've set up ${task}. ${result.pipeline ? 'The pipeline is' : 'Everything is'} configured and ready.`,
+    'shadcn-ui-builder': `I've built the UI for ${task}. ${result.components ? `Used ${result.components} components` : 'The interface is complete'}.`,
+    'product-manager': `I've completed ${task}. ${result.stories ? `Created ${result.stories} user stories` : 'Requirements are documented'}.`,
+    'marketing-writer': `I've written ${task}. The content is ${result.wordCount ? `${result.wordCount} words and` : ''} ready for publication.`,
+    'api-documenter': `I've documented ${task}. ${result.endpoints ? `Covered ${result.endpoints} endpoints` : 'API documentation is complete'}.`,
+    'test-runner': `Test run complete for ${task}. ${result.passed && result.total ? `${result.passed}/${result.total} tests passed` : 'See results above'}.`,
+    'refactor': `I've refactored ${task}. ${result.improvements ? `Made ${result.improvements} improvements` : 'Code structure is improved'}.`,
+    'doc-writer': `I've written documentation for ${task}. ${result.sections ? `Added ${result.sections} sections` : 'Documentation is complete'}.`,
+    'meta-agent': `I've created the ${task} agent. It's ready to use with the specialized capabilities you requested.`,
+    'default': `I've completed ${task}. Everything is ready for the next step.`
+  };
+  
+  return templates[agentName] || templates.default;
+}
+
+/**
+ * Instructions for agents to include voice announcements
+ */
+export const VOICE_ANNOUNCEMENT_INSTRUCTIONS = `
+## Voice Announcements
+
+When you complete a task and voice is enabled, announce your completion using:
+
+\`\`\`
+mcp__ElevenLabs__text_to_speech(
+  text: "[Your completion message]",
+  voice_id: "[Your assigned voice ID]",
+  output_directory: "[Current directory]"
+)
+\`\`\`
+
+Your voice ID: {{VOICE_ID}}
+
+Keep announcements:
+- Concise (2-3 sentences max)
+- Informative (what you did, key outcomes)
+- Forward-looking (suggest next steps)
+`;
+
+/**
+ * Check if voice announcements are enabled
+ */
+export function isVoiceEnabled() {
+  const config = getVoiceConfig();
+  return config.enabled && config.provider === 'mcp';
+}
+
+/**
+ * Generate hook configuration for agent voice
+ */
+export function generateVoiceHook(agentName) {
+  if (!isVoiceEnabled()) {
+    return null;
+  }
+  
+  return {
+    type: 'TaskComplete',
+    action: 'mcp_tool',
+    tool: 'mcp__ElevenLabs__text_to_speech',
+    parameters: {
+      voice_id: getAgentVoiceId(agentName),
+      output_directory: process.cwd()
+    }
+  };
+}

--- a/src/utils/voice/cleanup.js
+++ b/src/utils/voice/cleanup.js
@@ -1,0 +1,112 @@
+/**
+ * Voice file cleanup utilities
+ */
+
+import { unlink } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { getVoiceConfig } from '../config.js';
+
+/**
+ * Clean up voice files after playback
+ * @param {string} filePath - Path to the audio file
+ * @param {Object} options - Cleanup options
+ */
+export async function cleanupVoiceFile(filePath, options = {}) {
+  const config = getVoiceConfig();
+  
+  // Check if cleanup is enabled
+  const shouldCleanup = options.cleanup !== undefined ? options.cleanup : config.autoCleanup;
+  
+  if (!shouldCleanup) {
+    return { cleaned: false, reason: 'Cleanup disabled' };
+  }
+  
+  // Add delay if specified (to ensure playback completes)
+  if (options.delay) {
+    await new Promise(resolve => setTimeout(resolve, options.delay));
+  }
+  
+  try {
+    if (existsSync(filePath)) {
+      await unlink(filePath);
+      return { cleaned: true, file: filePath };
+    } else {
+      return { cleaned: false, reason: 'File not found' };
+    }
+  } catch (error) {
+    return { cleaned: false, reason: error.message };
+  }
+}
+
+/**
+ * Clean up old TTS files in a directory
+ * @param {string} directory - Directory to clean
+ * @param {number} maxAge - Maximum age in milliseconds (default: 1 hour)
+ */
+export async function cleanupOldVoiceFiles(directory, maxAge = 3600000) {
+  const { readdir, stat } = await import('fs/promises');
+  
+  try {
+    const files = await readdir(directory);
+    const now = Date.now();
+    const cleaned = [];
+    
+    for (const file of files) {
+      // Only clean TTS files (tts_*.mp3)
+      if (!file.startsWith('tts_') || !file.endsWith('.mp3')) {
+        continue;
+      }
+      
+      const filePath = join(directory, file);
+      const stats = await stat(filePath);
+      const age = now - stats.mtimeMs;
+      
+      if (age > maxAge) {
+        await unlink(filePath);
+        cleaned.push(file);
+      }
+    }
+    
+    return { cleaned: cleaned.length, files: cleaned };
+  } catch (error) {
+    return { cleaned: 0, error: error.message };
+  }
+}
+
+/**
+ * Schedule periodic cleanup of old voice files
+ * @param {string} directory - Directory to monitor
+ * @param {Object} options - Cleanup options
+ */
+export function scheduleVoiceCleanup(directory, options = {}) {
+  const interval = options.interval || 3600000; // Default: 1 hour
+  const maxAge = options.maxAge || 3600000; // Default: 1 hour
+  
+  const cleanup = async () => {
+    const result = await cleanupOldVoiceFiles(directory, maxAge);
+    if (result.cleaned > 0) {
+      console.log(`Cleaned ${result.cleaned} old voice files`);
+    }
+  };
+  
+  // Initial cleanup
+  cleanup();
+  
+  // Schedule periodic cleanup
+  return setInterval(cleanup, interval);
+}
+
+/**
+ * Get cleanup settings for voice files
+ */
+export function getCleanupSettings() {
+  const config = getVoiceConfig();
+  
+  return {
+    autoCleanup: config.autoCleanup !== false, // Default: true
+    cleanupDelay: config.cleanupDelay || 5000, // Default: 5 seconds
+    maxAge: config.maxAge || 3600000, // Default: 1 hour
+    cleanupInterval: config.cleanupInterval || 3600000 // Default: 1 hour
+  };
+}

--- a/templates/.env.sample
+++ b/templates/.env.sample
@@ -1,0 +1,22 @@
+# Sub-Agents Configuration
+# Copy this to .env and fill in your API keys
+
+# Core API Keys
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+ELEVENLABS_API_KEY=
+
+# Additional AI Services (Optional)
+DEEPSEEK_API_KEY=
+GEMINI_API_KEY=
+GROQ_API_KEY=
+FIRECRAWL_API_KEY=
+
+# Local Configuration
+ENGINEER_NAME=
+OLLAMA_HOST=
+
+# Sub-Agents Settings
+CLAUDE_AGENTS_VOICE_ENABLED=true
+CLAUDE_AGENTS_VOICE_PROVIDER=auto
+CLAUDE_AGENTS_DEBUG=false

--- a/templates/.mcp.json.sample
+++ b/templates/.mcp.json.sample
@@ -1,0 +1,31 @@
+{
+  "mcpServers": {
+    "ElevenLabs": {
+      "command": "uvx",
+      "args": [
+        "elevenlabs-mcp"
+      ],
+      "env": {
+        "ELEVENLABS_API_KEY": "${ELEVENLABS_API_KEY}"
+      }
+    },
+    "PyPI": {
+      "command": "uvx",
+      "args": [
+        "mcp-pypi"
+      ]
+    },
+    "Context7": {
+      "command": "npx",
+      "args": [
+        "@context7/mcp-server"
+      ]
+    },
+    "ShadCN-UI": {
+      "command": "npx",
+      "args": [
+        "shadcn-ui-mcp-server"
+      ]
+    }
+  }
+}

--- a/templates/agent-handoff-instructions.md
+++ b/templates/agent-handoff-instructions.md
@@ -1,0 +1,32 @@
+## Context Management & Handoffs
+
+When you complete your task:
+
+1. **Store only essential outputs** - Keep data minimal to preserve context
+2. **Return a brief summary** - One line summarizing what you accomplished
+3. **Exit immediately** - Don't wait for feedback or next steps
+
+### Input Handling
+If you have inputs from previous agents:
+- They will be provided as context at the start
+- Use only what's relevant to your specific task
+- Don't pass along unnecessary data
+
+### Output Format
+When your task produces outputs for other agents:
+```javascript
+// Good - Minimal, focused data
+{
+  "endpoints": ["/api/users", "/api/products"],
+  "status": "implemented"
+}
+
+// Bad - Too much context
+{
+  "full_implementation": "... 1000 lines of code ...",
+  "entire_conversation": "... previous context ...",
+  "unrelated_data": "..."
+}
+```
+
+Remember: Each agent works in isolation. Keep handoffs lightweight!

--- a/templates/agent-voice-instructions.md
+++ b/templates/agent-voice-instructions.md
@@ -1,0 +1,52 @@
+# Voice Announcement Instructions for Agents
+
+When you complete a task, announce your completion using the ElevenLabs MCP tool.
+
+## Format
+
+Use this exact format when calling the MCP tool:
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've completed [what you did]. Next, we can [what's next].",
+  voice_id: "[your_voice_id]",
+  output_directory: "[current_directory]"
+)
+```
+
+## Example
+
+```
+mcp__ElevenLabs__text_to_speech(
+  text: "I've completed the user authentication API endpoints. All tests are passing and the documentation is updated. Next, we can implement the authorization middleware.",
+  voice_id: "WejK3H1m7MI9CHnIjW9K",
+  output_directory: "."
+)
+```
+
+## Voice IDs by Agent Type
+
+- **project-planner**: WejK3H1m7MI9CHnIjW9K (Ashlee - Pleasant)
+- **api-developer**: onwK4e9ZLuTAKqWW03F9 (Daniel - Professional)
+- **frontend-developer**: EXAVITQu4vr4xnSDxMaL (Bella - Creative)
+- **tdd-specialist**: ErXwobaYiN019PkySvjV (Antoni - Precise)
+- **code-reviewer**: 21m00Tcm4TlvDq8ikWAM (Rachel - Authoritative)
+- **debugger**: yoZ06aMxZJJ28mfd3POQ (Sam - Problem Solver)
+- **security-scanner**: flq6f7yk4E4fJM5XTYuZ (Michael - Serious)
+- **devops-engineer**: 2EiwWnXFnvU5JabPnv8n (Clyde - Technical)
+
+## When to Announce
+
+1. **Task Completion**: Always announce when you finish the main task
+2. **Major Milestones**: Announce completion of significant sub-tasks
+3. **Errors Resolved**: Announce when you fix critical issues
+4. **Next Steps**: Always include what can be done next
+
+## Message Structure
+
+Your announcement should include:
+1. What you completed
+2. Key outcomes or results
+3. What the next logical step would be
+
+Keep announcements concise but informative - aim for 2-3 sentences.

--- a/templates/hooks/notification.py
+++ b/templates/hooks/notification.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-dotenv",
+# ]
+# ///
+
+import argparse
+import json
+import os
+import sys
+import subprocess
+from pathlib import Path
+from datetime import datetime
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass  # dotenv is optional
+
+
+def get_tts_script_path():
+    """
+    Determine which TTS script to use based on available API keys.
+    Priority order: ElevenLabs > OpenAI > pyttsx3
+    """
+    script_dir = Path(__file__).parent
+    tts_dir = script_dir / "utils" / "tts"
+    
+    # Check for ElevenLabs (highest priority for quality)
+    if os.getenv('ELEVENLABS_API_KEY'):
+        elevenlabs_script = tts_dir / "elevenlabs_tts.py"
+        if elevenlabs_script.exists():
+            return str(elevenlabs_script)
+    
+    # Check for OpenAI API key (second priority)
+    if os.getenv('OPENAI_API_KEY'):
+        openai_script = tts_dir / "openai_tts.py"
+        if openai_script.exists():
+            return str(openai_script)
+    
+    # Fall back to pyttsx3 (no API key required)
+    pyttsx3_script = tts_dir / "local_tts.py"
+    if pyttsx3_script.exists():
+        return str(pyttsx3_script)
+    
+    return None
+
+
+def get_notification_message(message):
+    """
+    Convert notification message to a more natural spoken version.
+    """
+    # Common notification transformations
+    if "permission" in message.lower():
+        # Extract tool name if present
+        if "to use" in message.lower():
+            parts = message.split("to use")
+            if len(parts) > 1:
+                tool_name = parts[1].strip().rstrip('.')
+                return f"Permission needed for {tool_name}"
+        return "Claude needs your permission"
+    
+    elif "waiting for your input" in message.lower():
+        return "Claude is waiting for you"
+    
+    elif "idle" in message.lower():
+        return "Claude is ready for your input"
+    
+    # Default: use the message as-is but make it more concise
+    # Remove "Claude" from beginning if present
+    if message.startswith("Claude "):
+        message = message[7:]
+    
+    # Truncate very long messages
+    if len(message) > 50:
+        message = message[:47] + "..."
+    
+    return message
+
+
+def main():
+    try:
+        # Read JSON input from stdin
+        input_data = json.load(sys.stdin)
+        
+        # Extract notification message
+        message = input_data.get("message", "")
+        
+        if not message:
+            sys.exit(0)
+        
+        # Get TTS script
+        tts_script = get_tts_script_path()
+        if not tts_script:
+            sys.exit(0)  # No TTS available
+        
+        # Convert to natural speech
+        spoken_message = get_notification_message(message)
+        
+        # Announce via TTS
+        subprocess.run([
+            "uv", "run", tts_script, spoken_message
+        ], 
+        capture_output=True,  # Suppress output
+        timeout=10
+        )
+        
+        # Optional: Also use system notification if available
+        try:
+            # Try notify-send on Linux
+            subprocess.run([
+                "notify-send", "-a", "Claude Code", "Claude Code", message
+            ], capture_output=True, timeout=2)
+        except:
+            try:
+                # Try osascript on macOS
+                subprocess.run([
+                    "osascript", "-e", 
+                    f'display notification "{message}" with title "Claude Code"'
+                ], capture_output=True, timeout=2)
+            except:
+                pass  # No system notification available
+        
+        # Log for debugging (optional)
+        log_dir = os.path.join(os.getcwd(), "logs")
+        if os.path.exists(log_dir):
+            log_path = os.path.join(log_dir, "notifications.json")
+            try:
+                logs = []
+                if os.path.exists(log_path):
+                    with open(log_path, 'r') as f:
+                        logs = json.load(f)
+                
+                logs.append({
+                    "timestamp": datetime.now().isoformat(),
+                    "message": message,
+                    "spoken": spoken_message
+                })
+                
+                # Keep last 50 entries
+                logs = logs[-50:]
+                
+                with open(log_path, 'w') as f:
+                    json.dump(logs, f, indent=2)
+            except:
+                pass
+        
+        sys.exit(0)
+        
+    except Exception:
+        # Fail silently
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/hooks/post_tool_use.py
+++ b/templates/hooks/post_tool_use.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-dotenv",
+# ]
+# ///
+
+import argparse
+import json
+import os
+import sys
+import subprocess
+from pathlib import Path
+from datetime import datetime
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass  # dotenv is optional
+
+
+def get_tts_script_path():
+    """
+    Determine which TTS script to use based on available API keys.
+    Priority order: ElevenLabs MCP > ElevenLabs > OpenAI > pyttsx3
+    """
+    script_dir = Path(__file__).parent
+    tts_dir = script_dir / "utils" / "tts"
+    
+    # Check for ElevenLabs (highest priority for quality)
+    if os.getenv('ELEVENLABS_API_KEY'):
+        # First try MCP if in Claude Code
+        elevenlabs_mcp_script = tts_dir / "elevenlabs_mcp.py"
+        if elevenlabs_mcp_script.exists():
+            return str(elevenlabs_mcp_script)
+            
+        # Fallback to direct ElevenLabs
+        elevenlabs_script = tts_dir / "elevenlabs_tts.py"
+        if elevenlabs_script.exists():
+            return str(elevenlabs_script)
+    
+    # Check for OpenAI API key (second priority)
+    if os.getenv('OPENAI_API_KEY'):
+        openai_script = tts_dir / "openai_tts.py"
+        if openai_script.exists():
+            return str(openai_script)
+    
+    # Fall back to pyttsx3 (no API key required)
+    pyttsx3_script = tts_dir / "local_tts.py"
+    if pyttsx3_script.exists():
+        return str(pyttsx3_script)
+    
+    return None
+
+
+def summarize_tool_result(tool_name, tool_input, tool_response):
+    """
+    Use LLM to create a short summary of what the tool did.
+    """
+    script_dir = Path(__file__).parent
+    llm_dir = script_dir / "utils" / "llm"
+    
+    # Build context about what happened
+    context = f"Tool: {tool_name}\n"
+    
+    # Add relevant arguments from tool_input
+    if tool_name == "Task":
+        # For Task tool, check various possible fields
+        if "prompt" in tool_input:
+            context += f"Task: {tool_input['prompt']}\n"
+        elif "description" in tool_input:
+            context += f"Task: {tool_input['description']}\n"
+        elif "task" in tool_input:
+            context += f"Task: {tool_input['task']}\n"
+    elif tool_name in ["Write", "Edit", "MultiEdit"]:
+        if "file_path" in tool_input:
+            context += f"File: {tool_input['file_path']}\n"
+    elif tool_name == "Read":
+        if "file_path" in tool_input:
+            context += f"Read: {tool_input['file_path']}\n"
+    
+    # Add result info from tool_response if available
+    if tool_response:
+        if isinstance(tool_response, dict):
+            if "success" in tool_response and tool_response["success"]:
+                context += f"Result: Completed successfully\n"
+            elif "output" in tool_response:
+                # For Task tool, output contains the agent's response
+                context += f"Result: Agent completed task\n"
+            elif "error" in tool_response:
+                context += f"Result: Error occurred\n"
+    
+    # Create prompt for summarization
+    prompt = f"""Summarize this tool completion in 5-10 words for a voice announcement.
+Focus on WHAT was done, not technical details.
+Be conversational and natural.
+
+{context}
+
+Examples of good summaries:
+- "Documentation created successfully"
+- "API developer finished the endpoints"
+- "Tests are now passing"
+- "File updated with new changes"
+- "Code review completed"
+
+Summary:"""
+    
+    # Try OpenAI first
+    if os.getenv('OPENAI_API_KEY'):
+        oai_script = llm_dir / "oai.py"
+        if oai_script.exists():
+            try:
+                result = subprocess.run([
+                    "uv", "run", str(oai_script), prompt
+                ], 
+                capture_output=True,
+                text=True,
+                timeout=10
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    return result.stdout.strip()
+            except:
+                pass
+    
+    # Try Anthropic as fallback
+    if os.getenv('ANTHROPIC_API_KEY'):
+        anth_script = llm_dir / "anth.py"
+        if anth_script.exists():
+            try:
+                result = subprocess.run([
+                    "uv", "run", str(anth_script), prompt
+                ], 
+                capture_output=True,
+                text=True,
+                timeout=10
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    return result.stdout.strip()
+            except:
+                pass
+    
+    # Fallback messages based on tool
+    if tool_name == "Task":
+        return "Sub-agent completed its task"
+    elif tool_name == "Write":
+        return "File written successfully"
+    elif tool_name == "Edit" or tool_name == "MultiEdit":
+        return "File edited successfully"
+    else:
+        return f"{tool_name} completed"
+
+
+def main():
+    try:
+        # Read JSON input from stdin
+        input_data = json.load(sys.stdin)
+        
+        # Extract tool information based on documentation
+        tool_name = input_data.get("tool_name", "")
+        tool_input = input_data.get("tool_input", {})
+        tool_response = input_data.get("tool_response", {})
+        
+        # Skip certain tools that shouldn't trigger announcements
+        skip_tools = ["TodoWrite", "Grep", "LS", "Bash", "Read", "Glob"]
+        if tool_name in skip_tools:
+            sys.exit(0)
+        
+        # Get TTS script
+        tts_script = get_tts_script_path()
+        if not tts_script:
+            sys.exit(0)  # No TTS available
+        
+        # Get summary of what was done
+        summary = summarize_tool_result(tool_name, tool_input, tool_response)
+        
+        # Announce via TTS
+        subprocess.run([
+            "uv", "run", tts_script, summary
+        ], 
+        capture_output=True,  # Suppress output
+        timeout=10
+        )
+        
+        # Log for debugging (optional)
+        log_dir = os.path.join(os.getcwd(), "logs")
+        if os.path.exists(log_dir):
+            log_path = os.path.join(log_dir, "post_tool_use.json")
+            try:
+                logs = []
+                if os.path.exists(log_path):
+                    with open(log_path, 'r') as f:
+                        logs = json.load(f)
+                
+                logs.append({
+                    "timestamp": datetime.now().isoformat(),
+                    "tool": tool_name,
+                    "summary": summary
+                })
+                
+                # Keep last 100 entries
+                logs = logs[-100:]
+                
+                with open(log_path, 'w') as f:
+                    json.dump(logs, f, indent=2)
+            except:
+                pass
+        
+        sys.exit(0)
+        
+    except Exception:
+        # Fail silently
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/hooks/post_tool_use_elevenlabs.py
+++ b/templates/hooks/post_tool_use_elevenlabs.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-dotenv",
+#     "openai",
+# ]
+# ///
+
+import json
+import sys
+import subprocess
+import os
+from pathlib import Path
+from datetime import datetime
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+def get_simple_summary(tool_name, tool_input, tool_response):
+    """
+    Create a simple summary without LLM first
+    """
+    if tool_name == "Task":
+        # Extract task description
+        task_desc = ""
+        if "prompt" in tool_input:
+            task_desc = tool_input['prompt']
+        elif "description" in tool_input:
+            task_desc = tool_input['description']
+        
+        # Extract agent name if present
+        if ':' in task_desc:
+            parts = task_desc.split(':', 1)
+            agent_name = parts[0].strip()
+            task_detail = parts[1].strip() if len(parts) > 1 else ""
+            # Shorten task detail
+            if len(task_detail) > 30:
+                task_detail = task_detail[:30] + "..."
+            return f"{agent_name} completed {task_detail}"
+        return "Agent task completed"
+    
+    elif tool_name == "Write":
+        file_path = tool_input.get("file_path", "")
+        if file_path:
+            file_name = Path(file_path).name
+            return f"Created {file_name}"
+        return "File created"
+    
+    elif tool_name in ["Edit", "MultiEdit"]:
+        file_path = tool_input.get("file_path", "")
+        if file_path:
+            file_name = Path(file_path).name
+            return f"Updated {file_name}"
+        return "File updated"
+    
+    return f"{tool_name} completed"
+
+def get_ai_summary(tool_name, tool_input, tool_response):
+    """
+    Use OpenAI to create a better summary
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+    
+    try:
+        from openai import OpenAI
+        client = OpenAI(api_key=api_key)
+        
+        # Build context
+        context = f"Tool: {tool_name}\n"
+        
+        if tool_name == "Task":
+            task_desc = tool_input.get("prompt", tool_input.get("description", ""))
+            context += f"Task: {task_desc}\n"
+            if tool_response and "output" in tool_response:
+                # Truncate output if too long
+                output = str(tool_response["output"])[:200]
+                context += f"Result: {output}\n"
+        
+        elif tool_name == "Write":
+            file_path = tool_input.get("file_path", "")
+            context += f"File: {file_path}\n"
+            context += "Action: Created new file\n"
+        
+        elif tool_name in ["Edit", "MultiEdit"]:
+            file_path = tool_input.get("file_path", "")
+            context += f"File: {file_path}\n"
+            context += "Action: Modified existing file\n"
+        
+        prompt = f"""Create a 3-7 word summary of this tool completion for voice announcement.
+Be specific about what was accomplished.
+
+{context}
+
+Examples of good summaries:
+- "Created user authentication module"
+- "Updated API endpoints"
+- "Documentation generator built"
+- "Fixed validation errors"
+- "Database schema created"
+
+Summary:"""
+        
+        response = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=20,
+            temperature=0.7,
+        )
+        
+        summary = response.choices[0].message.content.strip()
+        # Remove quotes if present
+        summary = summary.strip('"').strip("'")
+        return summary
+        
+    except Exception as e:
+        print(f"AI summary error: {e}", file=sys.stderr)
+        return None
+
+def announce_with_tts(summary):
+    """
+    Try ElevenLabs first, then fall back to local TTS
+    """
+    script_dir = Path(__file__).parent
+    tts_dir = script_dir / "utils" / "tts"
+    
+    # Try ElevenLabs first
+    if os.getenv('ELEVENLABS_API_KEY'):
+        elevenlabs_script = tts_dir / "elevenlabs_tts.py"
+        if elevenlabs_script.exists():
+            result = subprocess.run(
+                ["uv", "run", str(elevenlabs_script), summary],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+            if result.returncode == 0:
+                return "elevenlabs"
+            else:
+                print(f"ElevenLabs error: {result.stderr}", file=sys.stderr)
+    
+    # Fall back to local TTS
+    try:
+        subprocess.run(["say", summary], capture_output=True)
+        return "local"
+    except:
+        return "none"
+
+def main():
+    try:
+        # Read input
+        input_data = json.load(sys.stdin)
+        tool_name = input_data.get("tool_name", "")
+        tool_input = input_data.get("tool_input", {})
+        tool_response = input_data.get("tool_response", {})
+        
+        # Skip certain tools
+        if tool_name in ["TodoWrite", "Grep", "LS", "Bash", "Read", "Glob"]:
+            sys.exit(0)
+        
+        # Try AI summary first, fall back to simple summary
+        summary = get_ai_summary(tool_name, tool_input, tool_response)
+        if not summary:
+            summary = get_simple_summary(tool_name, tool_input, tool_response)
+        
+        # Announce with TTS (ElevenLabs or local)
+        tts_method = announce_with_tts(summary)
+        
+        # Log what we announced
+        log_dir = os.path.join(os.getcwd(), "logs")
+        if os.path.exists(log_dir):
+            log_path = os.path.join(log_dir, "voice_announcements.json")
+            logs = []
+            if os.path.exists(log_path):
+                try:
+                    with open(log_path, 'r') as f:
+                        logs = json.load(f)
+                except:
+                    logs = []
+            
+            logs.append({
+                "timestamp": datetime.now().isoformat(),
+                "tool": tool_name,
+                "summary": summary,
+                "ai_generated": bool(get_ai_summary(tool_name, tool_input, tool_response)),
+                "tts_method": tts_method
+            })
+            
+            # Keep last 50
+            logs = logs[-50:]
+            
+            with open(log_path, 'w') as f:
+                json.dump(logs, f, indent=2)
+        
+        print(f"Announced via {tts_method}: {summary}")
+        sys.exit(0)
+        
+    except Exception as e:
+        print(f"Hook error: {e}", file=sys.stderr)
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/templates/hooks/post_tool_use_mcp.py
+++ b/templates/hooks/post_tool_use_mcp.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-dotenv",
+# ]
+# ///
+
+import json
+import os
+import sys
+from pathlib import Path
+from datetime import datetime
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass  # dotenv is optional
+
+
+def get_tool_summary(tool_name, tool_input, tool_response):
+    """
+    Create a concise summary of what the tool did.
+    """
+    # Build context about what happened
+    if tool_name == "Task":
+        # For Task tool, extract agent and task info
+        task_desc = ""
+        if "prompt" in tool_input:
+            task_desc = tool_input['prompt']
+        elif "description" in tool_input:
+            task_desc = tool_input['description']
+        elif "task" in tool_input:
+            task_desc = tool_input['task']
+        
+        # Extract agent name if present
+        if ':' in task_desc:
+            agent_name = task_desc.split(':')[0].strip()
+            return f"{agent_name} completed task"
+        elif '(' in task_desc:
+            agent_name = task_desc.split('(')[0].strip()
+            return f"{agent_name} finished"
+        else:
+            return "Agent task complete"
+    
+    elif tool_name == "Write":
+        file_path = tool_input.get("file_path", "file")
+        file_name = Path(file_path).name
+        return f"{file_name} written"
+    
+    elif tool_name in ["Edit", "MultiEdit"]:
+        file_path = tool_input.get("file_path", "file")
+        file_name = Path(file_path).name
+        return f"{file_name} updated"
+    
+    elif tool_name == "TodoWrite":
+        return "Todos updated"
+    
+    else:
+        return f"{tool_name} complete"
+
+
+def main():
+    try:
+        # Read JSON input from stdin
+        input_data = json.load(sys.stdin)
+        
+        # Extract tool information
+        tool_name = input_data.get("tool_name", "")
+        tool_input = input_data.get("tool_input", {})
+        tool_response = input_data.get("tool_response", {})
+        
+        # Skip certain tools that shouldn't trigger announcements
+        skip_tools = ["TodoWrite", "Grep", "LS", "Bash", "Read", "Glob", "WebSearch", "WebFetch"]
+        if tool_name in skip_tools:
+            sys.exit(0)
+        
+        # Get summary of what was done
+        summary = get_tool_summary(tool_name, tool_input, tool_response)
+        
+        # Since we're in Claude Code with MCP, we can suggest using the work-completion-summary agent
+        # But hooks can't directly call MCP tools, so we'll just log for now
+        
+        # Log for debugging
+        log_dir = os.path.join(os.getcwd(), "logs")
+        if os.path.exists(log_dir):
+            log_path = os.path.join(log_dir, "post_tool_use.json")
+            try:
+                logs = []
+                if os.path.exists(log_path):
+                    with open(log_path, 'r') as f:
+                        logs = json.load(f)
+                
+                logs.append({
+                    "timestamp": datetime.now().isoformat(),
+                    "tool": tool_name,
+                    "summary": summary,
+                    "note": "Voice announcement via work-completion-summary agent"
+                })
+                
+                # Keep last 100 entries
+                logs = logs[-100:]
+                
+                with open(log_path, 'w') as f:
+                    json.dump(logs, f, indent=2)
+            except:
+                pass
+        
+        # Output message to transcript suggesting agent use
+        print(f"✓ {summary}")
+        
+        sys.exit(0)
+        
+    except Exception:
+        # Fail silently
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/hooks/stop.py
+++ b/templates/hooks/stop.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-dotenv",
+# ]
+# ///
+
+import argparse
+import json
+import os
+import sys
+import random
+import subprocess
+from pathlib import Path
+from datetime import datetime
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass  # dotenv is optional
+
+
+def get_completion_messages():
+    """Return list of friendly completion messages."""
+    return [
+        "Work complete!",
+        "All done!",
+        "Task finished!",
+        "Job complete!",
+        "Ready for next task!"
+    ]
+
+
+def get_tts_script_path():
+    """
+    Determine which TTS script to use based on available API keys and MCP.
+    Priority order: ElevenLabs MCP > OpenAI > local
+    """
+    # Get current script directory and construct utils/tts path
+    script_dir = Path(__file__).parent
+    tts_dir = script_dir / "utils" / "tts"
+    
+    # Check for ElevenLabs MCP first (highest priority)
+    elevenlabs_mcp_script = tts_dir / "elevenlabs_mcp.py"
+    if elevenlabs_mcp_script.exists():
+        return str(elevenlabs_mcp_script)
+    
+    # Check for OpenAI API key (second priority)
+    if os.getenv('OPENAI_API_KEY'):
+        openai_script = tts_dir / "openai_tts.py"
+        if openai_script.exists():
+            return str(openai_script)
+    
+    # Fall back to local TTS (no API key required)
+    local_script = tts_dir / "local_tts.py"
+    if local_script.exists():
+        return str(local_script)
+    
+    return None
+
+
+def get_llm_completion_message():
+    """
+    Generate completion message using available LLM services.
+    Priority order: OpenAI > Anthropic > fallback to random message
+    
+    Returns:
+        str: Generated or fallback completion message
+    """
+    # Get current script directory and construct utils/llm path
+    script_dir = Path(__file__).parent
+    llm_dir = script_dir / "utils" / "llm"
+    
+    # Try OpenAI first (highest priority)
+    if os.getenv('OPENAI_API_KEY'):
+        oai_script = llm_dir / "oai.py"
+        if oai_script.exists():
+            try:
+                result = subprocess.run([
+                    "uv", "run", str(oai_script), "--completion"
+                ], 
+                capture_output=True,
+                text=True,
+                timeout=10
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    return result.stdout.strip()
+            except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+                pass
+    
+    # Try Anthropic second
+    if os.getenv('ANTHROPIC_API_KEY'):
+        anth_script = llm_dir / "anth.py"
+        if anth_script.exists():
+            try:
+                result = subprocess.run([
+                    "uv", "run", str(anth_script), "--completion"
+                ], 
+                capture_output=True,
+                text=True,
+                timeout=10
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    return result.stdout.strip()
+            except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+                pass
+    
+    # Fallback to random predefined message
+    messages = get_completion_messages()
+    return random.choice(messages)
+
+def announce_completion():
+    """Announce completion using the best available TTS service."""
+    try:
+        tts_script = get_tts_script_path()
+        if not tts_script:
+            return  # No TTS scripts available
+        
+        # Get completion message (LLM-generated or fallback)
+        completion_message = get_llm_completion_message()
+        
+        # Call the TTS script with the completion message
+        subprocess.run([
+            "uv", "run", tts_script, completion_message
+        ], 
+        capture_output=True,  # Suppress output
+        timeout=10  # 10-second timeout
+        )
+        
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, FileNotFoundError):
+        # Fail silently if TTS encounters issues
+        pass
+    except Exception:
+        # Fail silently for any other errors
+        pass
+
+
+def main():
+    try:
+        # Parse command line arguments
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--chat', action='store_true', help='Copy transcript to chat.json')
+        args = parser.parse_args()
+        
+        # Read JSON input from stdin
+        input_data = json.load(sys.stdin)
+
+        # Extract required fields
+        session_id = input_data.get("session_id", "")
+        stop_hook_active = input_data.get("stop_hook_active", False)
+
+        # Ensure log directory exists
+        log_dir = os.path.join(os.getcwd(), "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        log_path = os.path.join(log_dir, "stop.json")
+
+        # Read existing log data or initialize empty list
+        if os.path.exists(log_path):
+            with open(log_path, 'r') as f:
+                try:
+                    log_data = json.load(f)
+                except (json.JSONDecodeError, ValueError):
+                    log_data = []
+        else:
+            log_data = []
+        
+        # Append new data
+        log_data.append(input_data)
+        
+        # Write back to file with formatting
+        with open(log_path, 'w') as f:
+            json.dump(log_data, f, indent=2)
+        
+        # Handle --chat switch
+        if args.chat and 'transcript_path' in input_data:
+            transcript_path = input_data['transcript_path']
+            if os.path.exists(transcript_path):
+                # Read .jsonl file and convert to JSON array
+                chat_data = []
+                try:
+                    with open(transcript_path, 'r') as f:
+                        for line in f:
+                            line = line.strip()
+                            if line:
+                                try:
+                                    chat_data.append(json.loads(line))
+                                except json.JSONDecodeError:
+                                    pass  # Skip invalid lines
+                    
+                    # Write to logs/chat.json
+                    chat_file = os.path.join(log_dir, 'chat.json')
+                    with open(chat_file, 'w') as f:
+                        json.dump(chat_data, f, indent=2)
+                except Exception:
+                    pass  # Fail silently
+
+        # Announce completion via TTS
+        announce_completion()
+
+        sys.exit(0)
+
+    except json.JSONDecodeError:
+        # Handle JSON decode errors gracefully
+        sys.exit(0)
+    except Exception:
+        # Handle any other errors gracefully
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/hooks/stop_with_agent.py
+++ b/templates/hooks/stop_with_agent.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-dotenv",
+# ]
+# ///
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from datetime import datetime
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass  # dotenv is optional
+
+
+def main():
+    try:
+        # Parse command line arguments
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--chat', action='store_true', help='Copy transcript to chat.json')
+        args = parser.parse_args()
+        
+        # Read JSON input from stdin
+        input_data = json.load(sys.stdin)
+
+        # Extract required fields
+        session_id = input_data.get("session_id", "")
+        stop_hook_active = input_data.get("stop_hook_active", False)
+        
+        # Don't trigger if already in a stop hook loop
+        if stop_hook_active:
+            sys.exit(0)
+
+        # Ensure log directory exists
+        log_dir = os.path.join(os.getcwd(), "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        log_path = os.path.join(log_dir, "stop.json")
+
+        # Read existing log data or initialize empty list
+        if os.path.exists(log_path):
+            with open(log_path, 'r') as f:
+                try:
+                    log_data = json.load(f)
+                except (json.JSONDecodeError, ValueError):
+                    log_data = []
+        else:
+            log_data = []
+        
+        # Append new data
+        log_data.append(input_data)
+        
+        # Write back to file with formatting
+        with open(log_path, 'w') as f:
+            json.dump(log_data, f, indent=2)
+        
+        # Handle --chat switch
+        if args.chat and 'transcript_path' in input_data:
+            transcript_path = input_data['transcript_path']
+            if os.path.exists(transcript_path):
+                # Read .jsonl file and convert to JSON array
+                chat_data = []
+                try:
+                    with open(transcript_path, 'r') as f:
+                        for line in f:
+                            line = line.strip()
+                            if line:
+                                try:
+                                    chat_data.append(json.loads(line))
+                                except json.JSONDecodeError:
+                                    pass  # Skip invalid lines
+                    
+                    # Write to logs/chat.json
+                    chat_file = os.path.join(log_dir, 'chat.json')
+                    with open(chat_file, 'w') as f:
+                        json.dump(chat_data, f, indent=2)
+                except Exception:
+                    pass  # Fail silently
+
+        # Instead of direct TTS, output JSON to trigger work-completion-summary agent
+        # This will be picked up by Claude Code if we return the right format
+        output = {
+            "decision": "block",
+            "reason": "Please run work-completion-summary agent: Task('work-completion-summary: Work session completed. Summarize what was accomplished and suggest next steps.')"
+        }
+        
+        print(json.dumps(output))
+        sys.exit(0)
+
+    except json.JSONDecodeError:
+        # Handle JSON decode errors gracefully
+        sys.exit(0)
+    except Exception:
+        # Handle any other errors gracefully
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/hooks/subagent_stop.py
+++ b/templates/hooks/subagent_stop.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-dotenv",
+# ]
+# ///
+
+import argparse
+import json
+import os
+import sys
+import subprocess
+from pathlib import Path
+from datetime import datetime
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass  # dotenv is optional
+
+
+def get_tts_script_path():
+    """
+    Determine which TTS script to use based on available API keys and MCP.
+    Priority order: ElevenLabs MCP > OpenAI > local
+    """
+    # Get current script directory and construct utils/tts path
+    script_dir = Path(__file__).parent
+    tts_dir = script_dir / "utils" / "tts"
+    
+    # Check for ElevenLabs MCP first (highest priority)
+    elevenlabs_mcp_script = tts_dir / "elevenlabs_mcp.py"
+    if elevenlabs_mcp_script.exists():
+        return str(elevenlabs_mcp_script)
+    
+    # Check for OpenAI API key (second priority)
+    if os.getenv('OPENAI_API_KEY'):
+        openai_script = tts_dir / "openai_tts.py"
+        if openai_script.exists():
+            return str(openai_script)
+    
+    # Fall back to local TTS (no API key required)
+    local_script = tts_dir / "local_tts.py"
+    if local_script.exists():
+        return str(local_script)
+    
+    return None
+
+
+def announce_subagent_completion():
+    """Announce subagent completion using the best available TTS service."""
+    try:
+        tts_script = get_tts_script_path()
+        if not tts_script:
+            return  # No TTS scripts available
+        
+        # Use fixed message for subagent completion
+        completion_message = "Subagent Complete"
+        
+        # Call the TTS script with the completion message
+        subprocess.run([
+            "uv", "run", tts_script, completion_message
+        ], 
+        capture_output=True,  # Suppress output
+        timeout=10  # 10-second timeout
+        )
+        
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, FileNotFoundError):
+        # Fail silently if TTS encounters issues
+        pass
+    except Exception:
+        # Fail silently for any other errors
+        pass
+
+
+def main():
+    try:
+        # Parse command line arguments
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--chat', action='store_true', help='Copy transcript to chat.json')
+        args = parser.parse_args()
+        
+        # Read JSON input from stdin
+        input_data = json.load(sys.stdin)
+
+        # Extract required fields
+        session_id = input_data.get("session_id", "")
+        stop_hook_active = input_data.get("stop_hook_active", False)
+
+        # Ensure log directory exists
+        log_dir = os.path.join(os.getcwd(), "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        log_path = os.path.join(log_dir, "subagent_stop.json")
+
+        # Read existing log data or initialize empty list
+        if os.path.exists(log_path):
+            with open(log_path, 'r') as f:
+                try:
+                    log_data = json.load(f)
+                except (json.JSONDecodeError, ValueError):
+                    log_data = []
+        else:
+            log_data = []
+        
+        # Append new data
+        log_data.append(input_data)
+        
+        # Write back to file with formatting
+        with open(log_path, 'w') as f:
+            json.dump(log_data, f, indent=2)
+        
+        # Handle --chat switch (same as stop.py)
+        if args.chat and 'transcript_path' in input_data:
+            transcript_path = input_data['transcript_path']
+            if os.path.exists(transcript_path):
+                # Read .jsonl file and convert to JSON array
+                chat_data = []
+                try:
+                    with open(transcript_path, 'r') as f:
+                        for line in f:
+                            line = line.strip()
+                            if line:
+                                try:
+                                    chat_data.append(json.loads(line))
+                                except json.JSONDecodeError:
+                                    pass  # Skip invalid lines
+                    
+                    # Write to logs/chat.json
+                    chat_file = os.path.join(log_dir, 'chat.json')
+                    with open(chat_file, 'w') as f:
+                        json.dump(chat_data, f, indent=2)
+                except Exception:
+                    pass  # Fail silently
+
+        # Announce subagent completion via TTS
+        announce_subagent_completion()
+
+        sys.exit(0)
+
+    except json.JSONDecodeError:
+        # Handle JSON decode errors gracefully
+        sys.exit(0)
+    except Exception:
+        # Handle any other errors gracefully
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/hooks/utils/llm/anth.py
+++ b/templates/hooks/utils/llm/anth.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "anthropic",
+#     "python-dotenv",
+# ]
+# ///
+
+import os
+import sys
+from dotenv import load_dotenv
+
+
+def prompt_llm(prompt_text):
+    """
+    Base Anthropic LLM prompting method using fastest model.
+
+    Args:
+        prompt_text (str): The prompt to send to the model
+
+    Returns:
+        str: The model's response text, or None if error
+    """
+    load_dotenv()
+
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        return None
+
+    try:
+        import anthropic
+
+        client = anthropic.Anthropic(api_key=api_key)
+
+        message = client.messages.create(
+            model="claude-3-5-haiku-20241022",  # Fastest Anthropic model
+            max_tokens=100,
+            temperature=0.7,
+            messages=[{"role": "user", "content": prompt_text}],
+        )
+
+        return message.content[0].text.strip()
+
+    except Exception:
+        return None
+
+
+def generate_completion_message():
+    """
+    Generate a completion message using Anthropic LLM.
+
+    Returns:
+        str: A natural language completion message, or None if error
+    """
+    engineer_name = os.getenv("ENGINEER_NAME", "").strip()
+
+    if engineer_name:
+        name_instruction = f"Sometimes (about 30% of the time) include the engineer's name '{engineer_name}' in a natural way."
+        examples = f"""Examples of the style: 
+- Standard: "Work complete!", "All done!", "Task finished!", "Ready for your next move!"
+- Personalized: "{engineer_name}, all set!", "Ready for you, {engineer_name}!", "Complete, {engineer_name}!", "{engineer_name}, we're done!" """
+    else:
+        name_instruction = ""
+        examples = """Examples of the style: "Work complete!", "All done!", "Task finished!", "Ready for your next move!" """
+
+    prompt = f"""Generate a short, friendly completion message for when an AI coding assistant finishes a task. 
+
+Requirements:
+- Keep it under 10 words
+- Make it positive and future focused
+- Use natural, conversational language
+- Focus on completion/readiness
+- Do NOT include quotes, formatting, or explanations
+- Return ONLY the completion message text
+{name_instruction}
+
+{examples}
+
+Generate ONE completion message:"""
+
+    response = prompt_llm(prompt)
+
+    # Clean up response - remove quotes and extra formatting
+    if response:
+        response = response.strip().strip('"').strip("'").strip()
+        # Take first line if multiple lines
+        response = response.split("\\n")[0].strip()
+
+    return response
+
+
+def main():
+    """Command line interface for testing."""
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "--completion":
+            message = generate_completion_message()
+            if message:
+                print(message)
+            else:
+                print("Error generating completion message")
+        else:
+            prompt_text = " ".join(sys.argv[1:])
+            response = prompt_llm(prompt_text)
+            if response:
+                print(response)
+            else:
+                print("Error calling Anthropic API")
+    else:
+        print("Usage: ./anth.py 'your prompt here' or ./anth.py --completion")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/hooks/utils/llm/oai.py
+++ b/templates/hooks/utils/llm/oai.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "openai",
+#     "python-dotenv",
+# ]
+# ///
+
+import os
+import sys
+from dotenv import load_dotenv
+
+
+def prompt_llm(prompt_text):
+    """
+    Base OpenAI LLM prompting method using fastest model.
+
+    Args:
+        prompt_text (str): The prompt to send to the model
+
+    Returns:
+        str: The model's response text, or None if error
+    """
+    load_dotenv()
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+
+    try:
+        from openai import OpenAI
+
+        client = OpenAI(api_key=api_key)
+
+        response = client.chat.completions.create(
+            model="gpt-4o-mini",  # Fast OpenAI model
+            messages=[{"role": "user", "content": prompt_text}],
+            max_tokens=100,
+            temperature=0.7,
+        )
+
+        return response.choices[0].message.content.strip()
+
+    except Exception:
+        return None
+
+
+def generate_completion_message():
+    """
+    Generate a completion message using OpenAI LLM.
+
+    Returns:
+        str: A natural language completion message, or None if error
+    """
+    engineer_name = os.getenv("ENGINEER_NAME", "").strip()
+
+    if engineer_name:
+        name_instruction = f"Sometimes (about 30% of the time) include the engineer's name '{engineer_name}' in a natural way."
+        examples = f"""Examples of the style: 
+- Standard: "Work complete!", "All done!", "Task finished!", "Ready for your next move!"
+- Personalized: "{engineer_name}, all set!", "Ready for you, {engineer_name}!", "Complete, {engineer_name}!", "{engineer_name}, we're done!" """
+    else:
+        name_instruction = ""
+        examples = """Examples of the style: "Work complete!", "All done!", "Task finished!", "Ready for your next move!" """
+
+    prompt = f"""Generate a short, friendly completion message for when an AI coding assistant finishes a task. 
+
+Requirements:
+- Keep it under 10 words
+- Make it positive and future focused
+- Use natural, conversational language
+- Focus on completion/readiness
+- Do NOT include quotes, formatting, or explanations
+- Return ONLY the completion message text
+{name_instruction}
+
+{examples}
+
+Generate ONE completion message:"""
+
+    response = prompt_llm(prompt)
+
+    # Clean up response - remove quotes and extra formatting
+    if response:
+        response = response.strip().strip('"').strip("'").strip()
+        # Take first line if multiple lines
+        response = response.split("\\n")[0].strip()
+
+    return response
+
+
+def main():
+    """Command line interface for testing."""
+    if len(sys.argv) > 1:
+        if sys.argv[1] == "--completion":
+            message = generate_completion_message()
+            if message:
+                print(message)
+            else:
+                print("Error generating completion message", file=sys.stderr)
+                sys.exit(1)
+        else:
+            prompt_text = " ".join(sys.argv[1:])
+            response = prompt_llm(prompt_text)
+            if response:
+                print(response)
+            else:
+                print("Error calling OpenAI API", file=sys.stderr)
+                sys.exit(1)
+    else:
+        print("Usage: ./oai.py 'your prompt here' or ./oai.py --completion", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/hooks/utils/tts/elevenlabs_mcp.py
+++ b/templates/hooks/utils/tts/elevenlabs_mcp.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "python-dotenv",
+# ]
+# ///
+
+import os
+import sys
+import json
+import subprocess
+from pathlib import Path
+from dotenv import load_dotenv
+
+
+def main():
+    """
+    ElevenLabs MCP TTS Script
+    
+    Uses ElevenLabs MCP server for high-quality text-to-speech via Claude Code.
+    Accepts optional text prompt as command-line argument.
+    
+    Usage:
+    - ./elevenlabs_mcp.py                    # Uses default text
+    - ./elevenlabs_mcp.py "Your custom text" # Uses provided text
+    
+    Features:
+    - Integration with Claude Code MCP
+    - Automatic voice selection
+    - High-quality voice synthesis via ElevenLabs API
+    - Optimized for hook usage (quick, reliable)
+    """
+    
+    # Load environment variables
+    load_dotenv()
+    
+    try:
+        print("🎙️  ElevenLabs MCP TTS")
+        print("=" * 25)
+        
+        # Get text from command line argument or use default
+        if len(sys.argv) > 1:
+            text = " ".join(sys.argv[1:])  # Join all arguments as text
+        else:
+            text = "Task completed successfully!"
+        
+        print(f"🎯 Text: {text}")
+        print("🔊 Generating and playing via MCP...")
+        
+        try:
+            # Use Claude Code CLI to invoke ElevenLabs MCP
+            # This assumes the ElevenLabs MCP server is configured in Claude Code
+            claude_cmd = [
+                "claude", "mcp", "call", "ElevenLabs", "text_to_speech",
+                "--text", text,
+                "--voice_name", "Adam",  # Default voice
+                "--model_id", "eleven_turbo_v2_5",  # Fast model
+                "--output_directory", str(Path.home() / "Desktop"),
+                "--speed", "1.0",
+                "--stability", "0.5",
+                "--similarity_boost", "0.75"
+            ]
+            
+            # Try to run the Claude MCP command
+            result = subprocess.run(
+                claude_cmd,
+                capture_output=True,
+                text=True,
+                timeout=15  # 15-second timeout for TTS generation
+            )
+            
+            if result.returncode == 0:
+                print("✅ TTS generated and played via MCP!")
+                
+                # Try to play the generated audio file
+                # Look for recently created audio files on Desktop
+                desktop = Path.home() / "Desktop"
+                audio_files = list(desktop.glob("*.mp3"))
+                
+                if audio_files:
+                    # Find the most recent audio file
+                    latest_audio = max(audio_files, key=lambda f: f.stat().st_mtime)
+                    
+                    # Try to play with system default audio player
+                    if sys.platform == "darwin":  # macOS
+                        subprocess.run(["afplay", str(latest_audio)], capture_output=True)
+                    elif sys.platform == "linux":  # Linux
+                        subprocess.run(["aplay", str(latest_audio)], capture_output=True)
+                    elif sys.platform == "win32":  # Windows
+                        subprocess.run(["start", str(latest_audio)], shell=True, capture_output=True)
+                    
+                    print("🎵 Audio playback attempted")
+                else:
+                    print("⚠️  Audio file not found on Desktop")
+            else:
+                print(f"❌ MCP Error: {result.stderr}")
+                # Fall back to simple notification
+                print("🔔 TTS via MCP failed - task completion noted")
+                
+        except subprocess.TimeoutExpired:
+            print("⏰ MCP TTS timed out - continuing...")
+        except FileNotFoundError:
+            print("❌ Claude CLI not found - MCP TTS unavailable")
+        except Exception as e:
+            print(f"❌ MCP Error: {e}")
+        
+    except Exception as e:
+        print(f"❌ Unexpected error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/hooks/utils/tts/elevenlabs_tts.py
+++ b/templates/hooks/utils/tts/elevenlabs_tts.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "elevenlabs",
+#     "python-dotenv",
+# ]
+# ///
+
+import os
+import sys
+from pathlib import Path
+from dotenv import load_dotenv
+
+def main():
+    """
+    ElevenLabs Turbo v2.5 TTS Script
+    
+    Uses ElevenLabs' Turbo v2.5 model for fast, high-quality text-to-speech.
+    Accepts optional text prompt as command-line argument.
+    
+    Usage:
+    - ./elevenlabs_tts.py                    # Uses default text
+    - ./elevenlabs_tts.py "Your custom text" # Uses provided text
+    
+    Features:
+    - Fast generation (optimized for real-time use)
+    - High-quality voice synthesis
+    - Stable production model
+    - Cost-effective for high-volume usage
+    """
+    
+    # Load environment variables
+    load_dotenv()
+    
+    # Get API key from environment
+    api_key = os.getenv('ELEVENLABS_API_KEY')
+    if not api_key:
+        print("❌ Error: ELEVENLABS_API_KEY not found in environment variables", file=sys.stderr)
+        print("Please add your ElevenLabs API key to .env file:", file=sys.stderr)
+        print("ELEVENLABS_API_KEY=your_api_key_here", file=sys.stderr)
+        sys.exit(1)
+    
+    try:
+        from elevenlabs.client import ElevenLabs
+        from elevenlabs import play
+        
+        # Initialize client
+        elevenlabs = ElevenLabs(api_key=api_key)
+        
+        # Get text from command line argument or use default
+        if len(sys.argv) > 1:
+            text = " ".join(sys.argv[1:])  # Join all arguments as text
+        else:
+            text = "Task completed successfully."
+        
+        try:
+            # Generate and play audio directly
+            audio = elevenlabs.text_to_speech.convert(
+                text=text,
+                voice_id="EXAVITQu4vr4xnSDxMaL",  # Sarah voice
+                model_id="eleven_turbo_v2_5",
+                output_format="mp3_44100_128",
+            )
+            
+            play(audio)
+            
+        except Exception as e:
+            print(f"❌ Error: {e}", file=sys.stderr)
+            sys.exit(1)
+        
+        
+    except ImportError:
+        print("❌ Error: elevenlabs package not installed", file=sys.stderr)
+        print("This script uses UV to auto-install dependencies.", file=sys.stderr)
+        print("Make sure UV is installed: https://docs.astral.sh/uv/", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ Unexpected error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/templates/hooks/utils/tts/local_tts.py
+++ b/templates/hooks/utils/tts/local_tts.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "pyttsx3",
+# ]
+# ///
+
+import sys
+import random
+import os
+
+
+def main():
+    """
+    Local TTS Script (pyttsx3)
+    
+    Uses pyttsx3 for offline text-to-speech synthesis.
+    Accepts optional text prompt as command-line argument.
+    
+    Usage:
+    - ./local_tts.py                    # Uses default text
+    - ./local_tts.py "Your custom text" # Uses provided text
+    
+    Features:
+    - Offline TTS (no API key required)
+    - Cross-platform compatibility
+    - Configurable voice settings
+    - Immediate audio playback
+    - Engineer name personalization support
+    """
+    
+    try:
+        import pyttsx3
+        
+        # Initialize TTS engine
+        engine = pyttsx3.init()
+        
+        # Configure engine settings
+        engine.setProperty('rate', 180)    # Speech rate (words per minute)
+        engine.setProperty('volume', 0.9)  # Volume (0.0 to 1.0)
+        
+        print("🎙️  Local TTS")
+        print("=" * 12)
+        
+        # Get text from command line argument or use default
+        if len(sys.argv) > 1:
+            text = " ".join(sys.argv[1:])  # Join all arguments as text
+        else:
+            # Default completion messages with engineer name support
+            engineer_name = os.getenv("ENGINEER_NAME", "").strip()
+            
+            if engineer_name and random.random() < 0.3:  # 30% chance to use name
+                personalized_messages = [
+                    f"{engineer_name}, all set!",
+                    f"Ready for you, {engineer_name}!",
+                    f"Complete, {engineer_name}!",
+                    f"{engineer_name}, we're done!",
+                    f"Task finished, {engineer_name}!"
+                ]
+                text = random.choice(personalized_messages)
+            else:
+                completion_messages = [
+                    "Work complete!",
+                    "All done!",
+                    "Task finished!",
+                    "Job complete!",
+                    "Ready for next task!",
+                    "Ready for your next move!",
+                    "All set!"
+                ]
+                text = random.choice(completion_messages)
+        
+        print(f"🎯 Text: {text}")
+        print("🔊 Speaking...")
+        
+        # Speak the text
+        engine.say(text)
+        engine.runAndWait()
+        
+        print("✅ Playback complete!")
+        
+    except ImportError:
+        print("❌ Error: pyttsx3 package not installed")
+        print("This script uses UV to auto-install dependencies.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/hooks/utils/tts/openai_tts.py
+++ b/templates/hooks/utils/tts/openai_tts.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "openai",
+#     "python-dotenv",
+# ]
+# ///
+
+import os
+import sys
+import asyncio
+from pathlib import Path
+from dotenv import load_dotenv
+
+
+async def main():
+    """
+    OpenAI TTS Script
+
+    Uses OpenAI's TTS model for high-quality text-to-speech.
+    Accepts optional text prompt as command-line argument.
+
+    Usage:
+    - ./openai_tts.py                    # Uses default text
+    - ./openai_tts.py "Your custom text" # Uses provided text
+
+    Features:
+    - OpenAI TTS-1 model (fast and reliable)
+    - Nova voice (engaging and warm)
+    - Direct audio streaming and playback
+    - Optimized for hook usage
+    """
+
+    # Load environment variables
+    load_dotenv()
+
+    # Get API key from environment
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        print("❌ Error: OPENAI_API_KEY not found in environment variables")
+        sys.exit(1)
+
+    try:
+        from openai import AsyncOpenAI
+
+        # Initialize OpenAI client
+        openai = AsyncOpenAI(api_key=api_key)
+
+        print("🎙️  OpenAI TTS")
+        print("=" * 15)
+
+        # Get text from command line argument or use default
+        if len(sys.argv) > 1:
+            text = " ".join(sys.argv[1:])  # Join all arguments as text
+        else:
+            text = "Task completed successfully!"
+
+        print(f"🎯 Text: {text}")
+        print("🔊 Generating audio...")
+
+        try:
+            # Generate audio using OpenAI TTS
+            response = await openai.audio.speech.create(
+                model="tts-1",
+                voice="nova",
+                input=text,
+                response_format="mp3",
+            )
+            
+            # Save to temporary file
+            audio_file = Path.home() / "Desktop" / "tts_completion.mp3"
+            with open(audio_file, "wb") as f:
+                async for chunk in response.iter_bytes():
+                    f.write(chunk)
+            
+            print("🎵 Playing audio...")
+            
+            # Play the audio file
+            import subprocess
+            if sys.platform == "darwin":  # macOS
+                subprocess.run(["afplay", str(audio_file)], capture_output=True)
+            elif sys.platform == "linux":  # Linux
+                subprocess.run(["aplay", str(audio_file)], capture_output=True)
+            elif sys.platform == "win32":  # Windows
+                subprocess.run(["start", str(audio_file)], shell=True, capture_output=True)
+
+            print("✅ Playback complete!")
+            
+            # Clean up the temporary file
+            try:
+                audio_file.unlink()
+            except:
+                pass
+
+        except Exception as e:
+            print(f"❌ Error: {e}")
+
+    except ImportError as e:
+        print("❌ Error: Required package not installed")
+        print("This script uses UV to auto-install dependencies.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ Unexpected error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/templates/settings.json
+++ b/templates/settings.json
@@ -1,0 +1,65 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mkdir:*)",
+      "Bash(uv:*)",
+      "Bash(find:*)",
+      "Bash(mv:*)",
+      "Bash(grep:*)",
+      "Bash(npm:*)",
+      "Bash(ls:*)",
+      "Bash(cp:*)",
+      "Write",
+      "Edit",
+      "Bash(chmod:*)",
+      "Bash(touch:*)"
+    ],
+    "deny": []
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/stop.py --chat"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/subagent_stop.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/post_tool_use_elevenlabs.py"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/notification.py"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
First published release since **v1.4.0**. Rolls up the voice/hooks work (drafted as 1.5.1) plus the packaging fixes required to ship it safely, and lands the community PR triage.

## Highlights
- **Voice announcements** — multi-provider TTS (ElevenLabs MCP → OpenAI → local) with completion announcements; new `voice`, `setup`, `chain`, `diagnose` commands.
- **Hooks** — Python hook templates installed on `init`; `settings.json` now **merged** instead of overwritten.
- **meta-agent** + **work-completion-summary** agent.

## Release-blocking fixes (this PR)
- 🔴 **Removed hardcoded `/Users/sem/code/sub-agents`** from 19 files (agent voice examples + voice hook) → now uses project cwd (`"."` / `process.cwd()`).
- 🔴 **context-forge command naming** (`install.js`): rewrite the copied `agent-<command>.md` frontmatter `name` to match the prefix, so an explicit `name:` can't defeat the conflict-avoidance rename. Verified with an end-to-end `listSlashCommands` simulation (name-present **and** name-absent).
- Repo hygiene: gitignore `*.mp3`, `tmp/`, dev-local `.claude/`; relocate misplaced `work-completion-summary` agent into its own dir.

## Community PRs
- ✅ #10 (`allowed-tools: Task`) merged separately; included in base.
- ✅ #5 (shadcn-ui-builder: add `Bash`, drop unresolvable MCP ref) folded into this PR.
- ⏭️ #9 (command `name:` field) lands on top of the context-forge fix above.

## Verification
- `npm test` → 3 suites pass · `node src/index.js --help` loads all commands · `npm pack --dry-run` → 127 files, no stray paths/artifacts, `templates/**` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)