### PR TITLE
chore: sync package-lock.json version to 1.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@webdevtoday/claude-agents",
-  "version": "1.5.0",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@webdevtoday/claude-agents",
-      "version": "1.5.0",
+      "version": "1.5.5",
       "license": "MIT",
       "os": [
         "darwin",


### PR DESCRIPTION
Lockfile `version` field read `1.5.0` while `package.json` is `1.5.5`. Bumps both lockfile version fields to match (no dependency-tree changes). Pre-publish hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)